### PR TITLE
feat: emit ES module alongside with CommonJS module

### DIFF
--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -779,9 +779,14 @@ export async function $onEmit(context: EmitContext) {
 				types: "./index.d.ts",
 				exports: {
 					".": {
-						types: "./index.d.ts",
-						import: "./index.mjs",
-						require: "./index.cjs",
+						import: {
+							types: "./index.d.mts",
+							default: "./index.mjs",
+						},
+						require: {
+							types: "./index.d.cts",
+							default: "./index.cjs",
+						},
 					},
 				},
 			},

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -720,7 +720,18 @@ export async function $onEmit(context: EmitContext) {
 	const typescriptSource = imports + entityDefinitions;
 
 	const declarations = await ts.transpileDeclaration(typescriptSource, {});
-	const javascript = await ts.transpileModule(typescriptSource, {});
+	const esm = ts.transpileModule(typescriptSource, {
+		compilerOptions: {
+			module: ts.ModuleKind.ESNext,
+			target: ts.ScriptTarget.ES2022,
+		},
+	});
+	const cjs = ts.transpileModule(typescriptSource, {
+		compilerOptions: {
+			module: ts.ModuleKind.CommonJS,
+			target: ts.ScriptTarget.ES2022,
+		},
+	});
 
 	// Fix validate function types in declarations
 	// TypeScript infers literal return types, but ElectroDB expects (value: T) => boolean
@@ -736,8 +747,23 @@ export async function $onEmit(context: EmitContext) {
 	});
 
 	await emitFile(context.program, {
-		path: resolvePath(context.emitterOutputDir, "index.js"),
-		content: javascript.outputText,
+		path: resolvePath(context.emitterOutputDir, "index.d.mts"),
+		content: fixedDeclarations,
+	});
+
+	await emitFile(context.program, {
+		path: resolvePath(context.emitterOutputDir, "index.d.cts"),
+		content: fixedDeclarations,
+	});
+
+	await emitFile(context.program, {
+		path: resolvePath(context.emitterOutputDir, "index.mjs"),
+		content: esm.outputText,
+	});
+
+	await emitFile(context.program, {
+		path: resolvePath(context.emitterOutputDir, "index.cjs"),
+		content: cjs.outputText,
 	});
 
 	await emitFile(context.program, {
@@ -747,8 +773,17 @@ export async function $onEmit(context: EmitContext) {
 				name: packageName ?? "entities",
 				version: packageVersion ?? "1.0.0",
 				description: "ElectroDB entities",
-				main: "./index.js",
+				type: "module",
+				main: "./index.cjs",
+				module: "./index.mjs",
 				types: "./index.d.ts",
+				exports: {
+					".": {
+						types: "./index.d.ts",
+						import: "./index.mjs",
+						require: "./index.cjs",
+					},
+				},
 			},
 			null,
 			2,

--- a/test/electrodb.test.ts
+++ b/test/electrodb.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { suite, test } from "node:test";
 import { Entity, Service } from "electrodb";
-import { Job, Person, Task } from "../build/entities/index.js";
+import { Job, Person, Task } from "../build/entities/index.mjs";
 
 const table = "test-table";
 

--- a/test/entities.test.ts
+++ b/test/entities.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { suite, test } from "node:test";
-import { Job, Person, Task } from "../build/entities/index.js";
+import { Job, Person, Task } from "../build/entities/index.mjs";
 
 suite("Job Entity", () => {
 	test("Job entity has correct model configuration", () => {


### PR DESCRIPTION
The emitter previously produced a CommonJS-only package (`ts.transpileModule` with no options defaults to `ModuleKind.CommonJS`, and the emitted `package.json` had no "type" field). This blocked consumers from mocking generated entities with Node's native `--experimental-test-module-mocks`, which requires ES modules.                                                                                                                                                                                 
                                                                                                                                                                                                                                                      
This change makes the emitter produce a dual package so consumers can pick either module system.                                                                                                                                                    
   
