### PR TITLE
fix: emit Record<T> as open CustomAttributeType("any") attribute instead of closed empty map

### DIFF
--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -352,10 +352,22 @@ function emitRecordModel(type: RecordModelType): Attribute {
 	};
 }
 
+function emitOpenRecordModel(type: RecordModelType): Attribute {
+	const valueTsType = emitTypeToTypeScript(type.indexer.value);
+	return {
+		// @ts-expect-error - RawCode is handled by stringifyObject at code generation time
+		type: new RawCode(
+			`CustomAttributeType<Record<string, ${valueTsType}>>("any")`,
+		),
+	};
+}
+
 function emitModel(type: Model): Attribute {
 	switch (type.name) {
 		case "Array":
 			return emitArrayModel(type as ArrayModelType);
+		case "Record":
+			return emitOpenRecordModel(type as RecordModelType);
 	}
 	return emitRecordModel(type as RecordModelType);
 }
@@ -427,6 +439,8 @@ function emitTypeToTypeScript(type: Type): string {
 				.join(" | ");
 			return variants;
 		}
+		case "Intrinsic":
+			return type.name === "unknown" ? "unknown" : "any";
 		default:
 			return "any";
 	}

--- a/test/entities.test.ts
+++ b/test/entities.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import { suite, test } from "node:test";
-import { Job, Person, Task } from "../build/entities/index.mjs";
+import { Document, Job, Person, Task } from "../build/entities/index.mjs";
 
 suite("Job Entity", () => {
 	test("Job entity has correct model configuration", () => {
@@ -489,6 +490,49 @@ suite("Person Entity", () => {
 			assert.equal(byAgeIndex.index, "lsi1");
 			// LSI has no collection
 			assert.equal("collection" in byAgeIndex, false);
+		});
+	});
+});
+
+suite("Open Record types (Record<T>)", () => {
+	// CustomAttributeType("any") evaluates to the string "any" at runtime,
+	// so an open attribute round-trips arbitrary keys instead of being a
+	// closed map ({ type: "map", properties: {} }) that strips all keys.
+	test("Record<unknown> emits an open 'any' attribute, not a closed map", () => {
+		assert.deepEqual(Document.attributes.payload, {
+			type: "any",
+			required: true,
+		});
+	});
+
+	test("Record<NamedModel> emits an open 'any' attribute", () => {
+		assert.deepEqual(Document.attributes.typedPayload, {
+			type: "any",
+			required: true,
+		});
+	});
+
+	test("generated output imports CustomAttributeType for open records", () => {
+		const source = readFileSync(
+			new URL("../build/entities/index.mjs", import.meta.url),
+			"utf8",
+		);
+		assert.match(
+			source,
+			/import \{[^}]*CustomAttributeType[^}]*\} from "electrodb"/,
+		);
+		assert.match(source, /payload: \{\s*type: CustomAttributeType\("any"\)/);
+	});
+
+	test("named model property still emits a closed map with its properties", () => {
+		assert.equal(Document.attributes.metadata.type, "map");
+		assert.deepEqual(Document.attributes.metadata.properties.street, {
+			type: "string",
+			required: true,
+		});
+		assert.deepEqual(Document.attributes.metadata.properties.country, {
+			type: ["NL", "US", "DE"],
+			required: true,
 		});
 	});
 });

--- a/test/main.tsp
+++ b/test/main.tsp
@@ -153,3 +153,17 @@ model Person {
 
     coffeePreferences: CoffeePreferences[];
 }
+
+@entity("document", "org")
+@index(
+    "documents",
+    {
+        pk: [Document.pk],
+    }
+)
+model Document {
+    pk: UUID;
+    payload: Record<unknown>;
+    typedPayload: Record<Contact>;
+    metadata: Address;
+}


### PR DESCRIPTION
An open record type (`Record<unknown>`, and `Record<T>` generally) fell through `emitModel` to `emitRecordModel`, which walked named properties (a Record has none) and returned `{ type: "map", properties: {} }`. ElectroDB treats a map with empty `properties` and no open flag as a **closed** map and strips every key on write — so any `Record<T>` attribute silently round-tripped to `{}` and dropped its payload.

## Fix
- `emitModel` gains a `case "Record"` (analogous to `case "Array"`) that emits an open attribute via the existing `CustomAttributeType` mechanism: `CustomAttributeType<Record<string, T>>("any")`. The codegen already auto-adds the `CustomAttributeType` import when that string appears.
- `emitTypeToTypeScript` gains an `Intrinsic` case so the `unknown` intrinsic yields `unknown` (was falling through to `any`); `Record<unknown>` → `CustomAttributeType<Record<string, unknown>>("any")`.
- Named models used as nested objects are unaffected — they keep `.name === "<ModelName>"` and still emit a closed `map` with their real `properties`.

## Tests
Added a `Document` entity to `test/main.tsp` and a suite covering: `Record<unknown>` and `Record<NamedModel>` emit the open `any` attribute, the generated module imports `CustomAttributeType`, and a named-model property still emits a closed map. All 71 tests pass.

Unblocks freeform-JSON attributes across services (TLM `ActivityInput/Output.value`, `Activity.payloadInput`; CIS `rawPayload`; PCS `JsonSchemaObject`).

Merge triggers the npm publish — leaving auto-merge off for the human/orchestrator to merge.