### PR TITLE
ci: use npm trusted publishing (OIDC) instead of NPM_TOKEN

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -36,13 +36,16 @@ jobs:
       contents: write # to be able to publish a GitHub release
       issues: write # to be able to comment on released issues
       pull-requests: write # to be able to comment on released pull requests
-      # id-token: write # to enable use of OIDC for npm provenance
+      id-token: write # to enable use of OIDC for trusted publishing and npm provenance
     steps:
       - uses: actions/checkout@v4
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: "lts/*"
+      - name: Upgrade npm
+        # Trusted publishing (OIDC) requires npm >= 11.5.1, newer than what Node LTS bundles
+        run: npm install -g npm@latest
       - name: Install dependencies
         run: npm ci
       # - name: Verify the integrity of provenance attestations and registry signatures for installed dependencies
@@ -50,5 +53,4 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release


### PR DESCRIPTION
## Why

The publish on the last merge to `main` failed with `npm error 401 Unauthorized` during semantic-release's `verifyConditions` step — the `NPM_TOKEN` secret is invalid/expired. Since trusted publishing is now configured on npm, we should drop the token entirely.

## Changes

- **Enable `id-token: write`** — OIDC trusted publishing requires it (was commented out).
- **Drop `NPM_TOKEN`** — trusted publishing uses a short-lived OIDC token, no long-lived secret. Its presence (invalid) was the cause of the 401.
- **Upgrade npm to `@latest`** — trusted publishing needs npm ≥ 11.5.1; Node LTS bundles npm 10.x. (`@semantic-release/npm@12.0.2` already supports OIDC.)

## Notes

- Requires the trusted publisher on npmjs.com to point at repo `mvhenten/typespec-electrodb-emitter` and workflow file `node.js.yml` (job `publish-npm`).
- The package is already published (0.1.1), so the 'no initial publish via OIDC' limitation doesn't apply.