### PR TITLE
build: upgrade semantic-release to v25 for tokenless OIDC publishing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,10 +25,59 @@
 				"eslint": "^9.15.0",
 				"prettier": "^3.3.3",
 				"recast": "^0.23.11",
-				"semantic-release": "^24.2.7",
+				"semantic-release": "^25.0.3",
 				"tsx": "^4.21.0",
 				"typescript": "^5.8.3"
 			}
+		},
+		"node_modules/@actions/core": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@actions/core/-/core-3.0.1.tgz",
+			"integrity": "sha512-a6d/Nwahm9fliVGRhdhofo40HjHQasUPusmc7vBfyky+7Z+P2A1J68zyFVaNcEclc/Se+eO595oAr5nwEIoIUA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@actions/exec": "^3.0.0",
+				"@actions/http-client": "^4.0.0"
+			}
+		},
+		"node_modules/@actions/exec": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@actions/exec/-/exec-3.0.0.tgz",
+			"integrity": "sha512-6xH/puSoNBXb72VPlZVm7vQ+svQpFyA96qdDBvhB8eNZOE8LtPf9L4oAsfzK/crCL8YZ+19fKYVnM63Sl+Xzlw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@actions/io": "^3.0.2"
+			}
+		},
+		"node_modules/@actions/http-client": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-4.0.1.tgz",
+			"integrity": "sha512-+Nvd1ImaOZBSoPbsUtEhv+1z99H12xzncCkz0a3RuehINE81FZSe2QTj3uvAPTcJX/SCzUQHQ0D1GrPMbrPitg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tunnel": "^0.0.6",
+				"undici": "^6.23.0"
+			}
+		},
+		"node_modules/@actions/http-client/node_modules/undici": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
+			"integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.17"
+			}
+		},
+		"node_modules/@actions/io": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@actions/io/-/io-3.0.2.tgz",
+			"integrity": "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@aws-crypto/sha256-browser": {
 			"version": "5.2.0",
@@ -2181,17 +2230,17 @@
 			}
 		},
 		"node_modules/@octokit/core": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.3.tgz",
-			"integrity": "sha512-oNXsh2ywth5aowwIa7RKtawnkdH6LgU1ztfP9AIUCQCvzysB+WeU8o2kyyosDPwBZutPpjZDKPQGIzzrfTWweQ==",
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
+			"integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/auth-token": "^6.0.0",
-				"@octokit/graphql": "^9.0.1",
-				"@octokit/request": "^10.0.2",
-				"@octokit/request-error": "^7.0.0",
-				"@octokit/types": "^14.0.0",
+				"@octokit/graphql": "^9.0.3",
+				"@octokit/request": "^10.0.6",
+				"@octokit/request-error": "^7.0.2",
+				"@octokit/types": "^16.0.0",
 				"before-after-hook": "^4.0.0",
 				"universal-user-agent": "^7.0.0"
 			},
@@ -2200,13 +2249,13 @@
 			}
 		},
 		"node_modules/@octokit/endpoint": {
-			"version": "11.0.0",
-			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.0.tgz",
-			"integrity": "sha512-hoYicJZaqISMAI3JfaDr1qMNi48OctWuOih1m80bkYow/ayPw6Jj52tqWJ6GEoFTk1gBqfanSoI1iY99Z5+ekQ==",
+			"version": "11.0.3",
+			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.3.tgz",
+			"integrity": "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@octokit/types": "^14.0.0",
+				"@octokit/types": "^16.0.0",
 				"universal-user-agent": "^7.0.2"
 			},
 			"engines": {
@@ -2214,14 +2263,14 @@
 			}
 		},
 		"node_modules/@octokit/graphql": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.1.tgz",
-			"integrity": "sha512-j1nQNU1ZxNFx2ZtKmL4sMrs4egy5h65OMDmSbVyuCzjOcwsHq6EaYjOTGXPQxgfiN8dJ4CriYHk6zF050WEULg==",
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.3.tgz",
+			"integrity": "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@octokit/request": "^10.0.2",
-				"@octokit/types": "^14.0.0",
+				"@octokit/request": "^10.0.6",
+				"@octokit/types": "^16.0.0",
 				"universal-user-agent": "^7.0.0"
 			},
 			"engines": {
@@ -2229,20 +2278,20 @@
 			}
 		},
 		"node_modules/@octokit/openapi-types": {
-			"version": "25.1.0",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-25.1.0.tgz",
-			"integrity": "sha512-idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA==",
+			"version": "27.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
+			"integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@octokit/plugin-paginate-rest": {
-			"version": "13.1.1",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-13.1.1.tgz",
-			"integrity": "sha512-q9iQGlZlxAVNRN2jDNskJW/Cafy7/XE52wjZ5TTvyhyOD904Cvx//DNyoO3J/MXJ0ve3rPoNWKEg5iZrisQSuw==",
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
+			"integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@octokit/types": "^14.1.0"
+				"@octokit/types": "^16.0.0"
 			},
 			"engines": {
 				"node": ">= 20"
@@ -2252,14 +2301,14 @@
 			}
 		},
 		"node_modules/@octokit/plugin-retry": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-8.0.1.tgz",
-			"integrity": "sha512-KUoYR77BjF5O3zcwDQHRRZsUvJwepobeqiSSdCJ8lWt27FZExzb0GgVxrhhfuyF6z2B2zpO0hN5pteni1sqWiw==",
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-8.1.0.tgz",
+			"integrity": "sha512-O1FZgXeiGb2sowEr/hYTr6YunGdSAFWnr2fyW39Ah85H8O33ELASQxcvOFF5LE6Tjekcyu2ms4qAzJVhSaJxTw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@octokit/request-error": "^7.0.0",
-				"@octokit/types": "^14.0.0",
+				"@octokit/request-error": "^7.0.2",
+				"@octokit/types": "^16.0.0",
 				"bottleneck": "^2.15.3"
 			},
 			"engines": {
@@ -2270,13 +2319,13 @@
 			}
 		},
 		"node_modules/@octokit/plugin-throttling": {
-			"version": "11.0.1",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-11.0.1.tgz",
-			"integrity": "sha512-S+EVhy52D/272L7up58dr3FNSMXWuNZolkL4zMJBNIfIxyZuUcczsQAU4b5w6dewJXnKYVgSHSV5wxitMSW1kw==",
+			"version": "11.0.3",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-11.0.3.tgz",
+			"integrity": "sha512-34eE0RkFCKycLl2D2kq7W+LovheM/ex3AwZCYN8udpi6bxsyjZidb2McXs69hZhLmJlDqTSP8cH+jSRpiaijBg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@octokit/types": "^14.0.0",
+				"@octokit/types": "^16.0.0",
 				"bottleneck": "^2.15.3"
 			},
 			"engines": {
@@ -2287,16 +2336,17 @@
 			}
 		},
 		"node_modules/@octokit/request": {
-			"version": "10.0.3",
-			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.3.tgz",
-			"integrity": "sha512-V6jhKokg35vk098iBqp2FBKunk3kMTXlmq+PtbV9Gl3TfskWlebSofU9uunVKhUN7xl+0+i5vt0TGTG8/p/7HA==",
+			"version": "10.0.10",
+			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.10.tgz",
+			"integrity": "sha512-KxNC2pTqqhszMNrf12ZRd4PonRgyJdsM4F/jySiddQK+DsRcfBtUvqn8t7UsyZhnRJHvX46OohDt5N3VqIWC2w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@octokit/endpoint": "^11.0.0",
-				"@octokit/request-error": "^7.0.0",
-				"@octokit/types": "^14.0.0",
-				"fast-content-type-parse": "^3.0.0",
+				"@octokit/endpoint": "^11.0.3",
+				"@octokit/request-error": "^7.0.2",
+				"@octokit/types": "^16.0.0",
+				"content-type": "^2.0.0",
+				"json-with-bigint": "^3.5.3",
 				"universal-user-agent": "^7.0.2"
 			},
 			"engines": {
@@ -2304,26 +2354,26 @@
 			}
 		},
 		"node_modules/@octokit/request-error": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.0.0.tgz",
-			"integrity": "sha512-KRA7VTGdVyJlh0cP5Tf94hTiYVVqmt2f3I6mnimmaVz4UG3gQV/k4mDJlJv3X67iX6rmN7gSHCF8ssqeMnmhZg==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.0.tgz",
+			"integrity": "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@octokit/types": "^14.0.0"
+				"@octokit/types": "^16.0.0"
 			},
 			"engines": {
 				"node": ">= 20"
 			}
 		},
 		"node_modules/@octokit/types": {
-			"version": "14.1.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-14.1.0.tgz",
-			"integrity": "sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==",
+			"version": "16.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
+			"integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@octokit/openapi-types": "^25.1.0"
+				"@octokit/openapi-types": "^27.0.0"
 			}
 		},
 		"node_modules/@pnpm/config.env-replace": {
@@ -2357,9 +2407,9 @@
 			"license": "ISC"
 		},
 		"node_modules/@pnpm/npm-conf": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-2.3.1.tgz",
-			"integrity": "sha512-c83qWb22rNRuB0UaVCI0uRPNRr8Z0FWnEIvT47jiHAmOIUHbBOg5XvV7pM5x+rKn9HRpjxquDbXYSXr3fAKFcw==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-3.0.2.tgz",
+			"integrity": "sha512-h104Kh26rR8tm+a3Qkc5S4VLYint3FE48as7+/5oCEcKR2idC/pF1G6AhIXKI+eHPJa/3J9i5z0Al47IeGHPkA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2412,68 +2462,71 @@
 			}
 		},
 		"node_modules/@semantic-release/github": {
-			"version": "11.0.3",
-			"resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-11.0.3.tgz",
-			"integrity": "sha512-T2fKUyFkHHkUNa5XNmcsEcDPuG23hwBKptfUVcFXDVG2cSjXXZYDOfVYwfouqbWo/8UefotLaoGfQeK+k3ep6A==",
+			"version": "12.0.8",
+			"resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-12.0.8.tgz",
+			"integrity": "sha512-tej5AAgK5X9wHRoDmYhecMXEHEkFeGOY1XsEblKxu8pIQwahzf1STYyr7iPU6Lpbg6C5I3N2w/ocXrBo+L7jhw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/core": "^7.0.0",
-				"@octokit/plugin-paginate-rest": "^13.0.0",
+				"@octokit/plugin-paginate-rest": "^14.0.0",
 				"@octokit/plugin-retry": "^8.0.0",
 				"@octokit/plugin-throttling": "^11.0.0",
 				"@semantic-release/error": "^4.0.0",
 				"aggregate-error": "^5.0.0",
 				"debug": "^4.3.4",
 				"dir-glob": "^3.0.1",
-				"globby": "^14.0.0",
-				"http-proxy-agent": "^7.0.0",
-				"https-proxy-agent": "^7.0.0",
+				"http-proxy-agent": "^9.0.0",
+				"https-proxy-agent": "^9.0.0",
 				"issue-parser": "^7.0.0",
 				"lodash-es": "^4.17.21",
 				"mime": "^4.0.0",
 				"p-filter": "^4.0.0",
+				"tinyglobby": "^0.2.14",
+				"undici": "^7.0.0",
 				"url-join": "^5.0.0"
 			},
 			"engines": {
-				"node": ">=20.8.1"
+				"node": "^22.14.0 || >= 24.10.0"
 			},
 			"peerDependencies": {
 				"semantic-release": ">=24.1.0"
 			}
 		},
 		"node_modules/@semantic-release/npm": {
-			"version": "12.0.2",
-			"resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-12.0.2.tgz",
-			"integrity": "sha512-+M9/Lb35IgnlUO6OSJ40Ie+hUsZLuph2fqXC/qrKn0fMvUU/jiCjpoL6zEm69vzcmaZJ8yNKtMBEKHWN49WBbQ==",
+			"version": "13.1.5",
+			"resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-13.1.5.tgz",
+			"integrity": "sha512-Hq5UxzoatN3LHiq2rTsWS54nCdqJHlsssGERCo8WlvdfFA9LoN0vO+OuKVSjtNapIc/S8C2LBj206wKLHg62mg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
+				"@actions/core": "^3.0.0",
 				"@semantic-release/error": "^4.0.0",
 				"aggregate-error": "^5.0.0",
+				"env-ci": "^11.2.0",
 				"execa": "^9.0.0",
 				"fs-extra": "^11.0.0",
 				"lodash-es": "^4.17.21",
 				"nerf-dart": "^1.0.0",
-				"normalize-url": "^8.0.0",
-				"npm": "^10.9.3",
+				"normalize-url": "^9.0.0",
+				"npm": "^11.6.2",
 				"rc": "^1.2.8",
-				"read-pkg": "^9.0.0",
+				"read-pkg": "^10.0.0",
 				"registry-auth-token": "^5.0.0",
 				"semver": "^7.1.2",
 				"tempy": "^3.0.0"
 			},
 			"engines": {
-				"node": ">=20.8.1"
+				"node": "^22.14.0 || >= 24.10.0"
 			},
 			"peerDependencies": {
 				"semantic-release": ">=20.1.0"
 			}
 		},
 		"node_modules/@semantic-release/release-notes-generator": {
-			"version": "14.0.3",
-			"resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-14.0.3.tgz",
-			"integrity": "sha512-XxAZRPWGwO5JwJtS83bRdoIhCiYIx8Vhr+u231pQAsdFIAbm19rSVJLdnBN+Avvk7CKvNQE/nJ4y7uqKH6WTiw==",
+			"version": "14.1.1",
+			"resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-14.1.1.tgz",
+			"integrity": "sha512-Pbd2e2XRMUD0OxehHpgd5/YghsE76cddkRHSoDvKLK+OCy4Ewxn49rWR631MEUU01lgwF/uyVXvbnVuu6+Z6VA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2482,9 +2535,7 @@
 				"conventional-commits-filter": "^5.0.0",
 				"conventional-commits-parser": "^6.0.0",
 				"debug": "^4.0.0",
-				"get-stream": "^7.0.0",
 				"import-from-esm": "^2.0.0",
-				"into-stream": "^7.0.0",
 				"lodash-es": "^4.17.21",
 				"read-package-up": "^11.0.0"
 			},
@@ -2495,14 +2546,118 @@
 				"semantic-release": ">=20.1.0"
 			}
 		},
-		"node_modules/@semantic-release/release-notes-generator/node_modules/get-stream": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-7.0.1.tgz",
-			"integrity": "sha512-3M8C1EOFN6r8AMUhwUAACIoXZJEOufDU5+0gFFN5uNs6XYOralD2Pqkl7m046va6x77FwposWXbAhPPIOus7mQ==",
+		"node_modules/@semantic-release/release-notes-generator/node_modules/hosted-git-info": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
+			"integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"lru-cache": "^10.0.1"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@semantic-release/release-notes-generator/node_modules/lru-cache": {
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/@semantic-release/release-notes-generator/node_modules/normalize-package-data": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
+			"integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"hosted-git-info": "^7.0.0",
+				"semver": "^7.3.5",
+				"validate-npm-package-license": "^3.0.4"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@semantic-release/release-notes-generator/node_modules/parse-json": {
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
+			"integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.26.2",
+				"index-to-position": "^1.1.0",
+				"type-fest": "^4.39.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@semantic-release/release-notes-generator/node_modules/read-package-up": {
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/read-package-up/-/read-package-up-11.0.0.tgz",
+			"integrity": "sha512-MbgfoNPANMdb4oRBNg5eqLbB2t2r+o5Ua1pNt8BqGp4I0FJZhuVSOj3PaBPni4azWuSzEdNn2evevzVmEk1ohQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"find-up-simple": "^1.0.0",
+				"read-pkg": "^9.0.0",
+				"type-fest": "^4.6.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@semantic-release/release-notes-generator/node_modules/read-pkg": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-9.0.1.tgz",
+			"integrity": "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/normalize-package-data": "^2.4.3",
+				"normalize-package-data": "^6.0.0",
+				"parse-json": "^8.0.0",
+				"type-fest": "^4.6.0",
+				"unicorn-magic": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@semantic-release/release-notes-generator/node_modules/type-fest": {
+			"version": "4.41.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+			"integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+			"dev": true,
+			"license": "(MIT OR CC0-1.0)",
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@semantic-release/release-notes-generator/node_modules/unicorn-magic": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
+			"integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=16"
+				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -3507,13 +3662,13 @@
 			}
 		},
 		"node_modules/agent-base": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-9.0.0.tgz",
+			"integrity": "sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">= 14"
+				"node": ">= 20"
 			}
 		},
 		"node_modules/aggregate-error": {
@@ -3739,9 +3894,9 @@
 			}
 		},
 		"node_modules/clean-stack": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-5.2.0.tgz",
-			"integrity": "sha512-TyUIUJgdFnCISzG5zu3291TAsE77ddchd0bepon1VVQrKLGKFED4iXFEDQ24mIPdPBbyE16PK3F8MYE1CmcBEQ==",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-5.3.0.tgz",
+			"integrity": "sha512-9ngPTOhYGQqNVSfeJkYXHmF7AGWp4/nN5D/QqNQs3Dvxd1Kk/WpjHfNujKHYUQ/5CoGyOyFNoWSPk5afzP0QVg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3949,6 +4104,20 @@
 			"dependencies": {
 				"ini": "^1.3.4",
 				"proto-list": "~1.2.1"
+			}
+		},
+		"node_modules/content-type": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+			"integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/conventional-changelog-angular": {
@@ -4230,9 +4399,9 @@
 			"license": "MIT"
 		},
 		"node_modules/env-ci": {
-			"version": "11.1.1",
-			"resolved": "https://registry.npmjs.org/env-ci/-/env-ci-11.1.1.tgz",
-			"integrity": "sha512-mT3ks8F0kwpo7SYNds6nWj0PaRh+qJxIeBVBXAKTN9hphAzZv7s0QAZQbqnB1fAv/r4pJUGE15BV9UrS31FP2w==",
+			"version": "11.2.0",
+			"resolved": "https://registry.npmjs.org/env-ci/-/env-ci-11.2.0.tgz",
+			"integrity": "sha512-D5kWfzkmaOQDioPmiviWAVtKmpPT4/iJmMVQxWxMPJTFyTkdc5JQUfc5iXEeWxcOdsYTKSAiA/Age4NUOqKsRA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4698,9 +4867,9 @@
 			}
 		},
 		"node_modules/execa": {
-			"version": "9.6.0",
-			"resolved": "https://registry.npmjs.org/execa/-/execa-9.6.0.tgz",
-			"integrity": "sha512-jpWzZ1ZhwUmeWRhS7Qv3mhpOhLfwI+uAX4e5fOcXqwMR7EcJ0pj2kV1CVzHVMX/LphnKWD3LObjZCoJ71lKpHw==",
+			"version": "9.6.1",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+			"integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4767,23 +4936,6 @@
 			"engines": {
 				"node": ">=4"
 			}
-		},
-		"node_modules/fast-content-type-parse": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-3.0.0.tgz",
-			"integrity": "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/fastify"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/fastify"
-				}
-			],
-			"license": "MIT"
 		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
@@ -4990,21 +5142,10 @@
 			"dev": true,
 			"license": "ISC"
 		},
-		"node_modules/from2": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
-			"integrity": "sha512-OMcX/4IC/uqEPVgGeyfN22LJk6AZrMkRZHxcHBMBvHScDGgwTm2GT2Wkgtocyd3JfZffjj2kYUDXXII0Fk9W0g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"inherits": "^2.0.1",
-				"readable-stream": "^2.0.0"
-			}
-		},
 		"node_modules/fs-extra": {
-			"version": "11.3.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
-			"integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+			"version": "11.3.5",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
+			"integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5051,6 +5192,19 @@
 			"license": "ISC",
 			"engines": {
 				"node": "6.* || 8.* || >= 10.*"
+			}
+		},
+		"node_modules/get-east-asian-width": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+			"integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/get-stream": {
@@ -5197,57 +5351,59 @@
 			}
 		},
 		"node_modules/hook-std": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/hook-std/-/hook-std-3.0.0.tgz",
-			"integrity": "sha512-jHRQzjSDzMtFy34AGj1DN+vq54WVuhSvKgrHf0OMiFQTwDD4L/qqofVEWjLOBMTn5+lCD3fPg32W9yOfnEJTTw==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/hook-std/-/hook-std-4.0.0.tgz",
+			"integrity": "sha512-IHI4bEVOt3vRUDJ+bFA9VUJlo7SzvFARPNLw75pqSmAOP2HmTWfFJtPvLBrDrlgjEYXY9zs7SFdHPQaJShkSCQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/hosted-git-info": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-8.1.0.tgz",
-			"integrity": "sha512-Rw/B2DNQaPBICNXEm8balFz9a6WpZrkCGpcWFpy7nCj+NyhSdqXipmfvtmWt9xGfp0wZnBxB+iVpLmQMYt47Tw==",
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+			"integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"lru-cache": "^10.0.1"
+				"lru-cache": "^11.1.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/http-proxy-agent": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-9.1.0.tgz",
+			"integrity": "sha512-2NxoveTT58mjYT4n3RPTEfCZGLMbidoO8XEieXfpSYxu+PQJ1qpx4ypwH6N+uF9twBPIvRRgvkvW5HUTYWENig==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"agent-base": "^7.1.0",
-				"debug": "^4.3.4"
+				"agent-base": "9.0.0",
+				"debug": "^4.3.4",
+				"proxy-agent-negotiate": "1.1.0"
 			},
 			"engines": {
-				"node": ">= 14"
+				"node": ">= 20"
 			}
 		},
 		"node_modules/https-proxy-agent": {
-			"version": "7.0.6",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-9.1.0.tgz",
+			"integrity": "sha512-ag87y7cJJ9/3+GxFr8Oy4O5faDsGRGnBGsJj/YjOSsSx/5eadKLYTMPlzuR6obgoCDDm0abAAZitXXQkMOPSpA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"agent-base": "^7.1.2",
-				"debug": "4"
+				"agent-base": "9.0.0",
+				"debug": "^4.3.4",
+				"proxy-agent-negotiate": "1.1.0"
 			},
 			"engines": {
-				"node": ">= 14"
+				"node": ">= 20"
 			}
 		},
 		"node_modules/human-signals": {
@@ -5347,9 +5503,9 @@
 			}
 		},
 		"node_modules/index-to-position": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.1.0.tgz",
-			"integrity": "sha512-XPdx9Dq4t9Qk1mTMbWONJqU7boCoumEH7fRET37HX5+khDUl3J2W6PdALxhILYlIYx2amlwYcRPp28p0tSiojg==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.2.0.tgz",
+			"integrity": "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -5372,23 +5528,6 @@
 			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
 			"dev": true,
 			"license": "ISC"
-		},
-		"node_modules/into-stream": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/into-stream/-/into-stream-7.0.0.tgz",
-			"integrity": "sha512-2dYz766i9HprMBasCMvHMuazJ7u4WzhJwo5kb3iPSiW/iRYV6uPari3zHoqZlnuaR7V1bEiNMxikhp37rdBXbw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"from2": "^2.3.0",
-				"p-is-promise": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
 		},
 		"node_modules/is-arrayish": {
 			"version": "0.2.1",
@@ -5499,9 +5638,9 @@
 			"license": "ISC"
 		},
 		"node_modules/issue-parser": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/issue-parser/-/issue-parser-7.0.1.tgz",
-			"integrity": "sha512-3YZcUUR2Wt1WsapF+S/WiA2WmlW0cWAoPccMqne7AxEBhCdFeTPjfv/Axb8V2gyCgY3nRw+ksZ3xSUX+R47iAg==",
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/issue-parser/-/issue-parser-7.0.2.tgz",
+			"integrity": "sha512-7atWPjhGEIX3JEtMrOYd8TKzboYlq+5sNbdl9POiLYOI14G5HZiQbZP0Xj5EZdrufQVXfJlpTV0hys0CuxwxZw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5590,10 +5729,17 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/json-with-bigint": {
+			"version": "3.5.8",
+			"resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.8.tgz",
+			"integrity": "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/jsonfile": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-			"integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5740,11 +5886,14 @@
 			"license": "MIT"
 		},
 		"node_modules/lru-cache": {
-			"version": "10.4.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+			"version": "11.5.1",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+			"integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
 			"dev": true,
-			"license": "ISC"
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
+			}
 		},
 		"node_modules/marked": {
 			"version": "15.0.12",
@@ -5866,9 +6015,9 @@
 			}
 		},
 		"node_modules/mime": {
-			"version": "4.0.7",
-			"resolved": "https://registry.npmjs.org/mime/-/mime-4.0.7.tgz",
-			"integrity": "sha512-2OfDPL+e03E0LrXaGYOtTFIYhiuzep94NSsuhrNULq+stylcJedcHdzHtz0atMUuGwJfFYs0YL5xeC/Ca2x0eQ==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-4.1.0.tgz",
+			"integrity": "sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw==",
 			"dev": true,
 			"funding": [
 				"https://github.com/sponsors/broofa"
@@ -6042,56 +6191,44 @@
 			}
 		},
 		"node_modules/normalize-package-data": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
-			"integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-8.0.0.tgz",
+			"integrity": "sha512-RWk+PI433eESQ7ounYxIp67CYuVsS1uYSonX3kA6ps/3LWfjVQa/ptEg6Y3T6uAMq1mWpX9PQ+qx+QaHpsc7gQ==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
-				"hosted-git-info": "^7.0.0",
+				"hosted-git-info": "^9.0.0",
 				"semver": "^7.3.5",
 				"validate-npm-package-license": "^3.0.4"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
-			}
-		},
-		"node_modules/normalize-package-data/node_modules/hosted-git-info": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
-			"integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"lru-cache": "^10.0.1"
-			},
-			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/normalize-url": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.2.tgz",
-			"integrity": "sha512-Ee/R3SyN4BuynXcnTaekmaVdbDAEiNrHqjQIA37mHU8G9pf7aaAD4ZX3XjBLo6rsdcxA/gtkcNYZLt30ACgynw==",
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-9.0.1.tgz",
+			"integrity": "sha512-ARftfC5HdUNu9jJeL8pHj8debUIHA2b91FizCoMzY4lG6dDX13jdvTK0TBe24IBDRf2HvJSzzwEPvmbkQWHRSg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=14.16"
+				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/npm": {
-			"version": "10.9.3",
-			"resolved": "https://registry.npmjs.org/npm/-/npm-10.9.3.tgz",
-			"integrity": "sha512-6Eh1u5Q+kIVXeA8e7l2c/HpnFFcwrkt37xDMujD5be1gloWa9p6j3Fsv3mByXXmqJHy+2cElRMML8opNT7xIJQ==",
+			"version": "11.16.0",
+			"resolved": "https://registry.npmjs.org/npm/-/npm-11.16.0.tgz",
+			"integrity": "sha512-A74XL8OxmcegZDMWPkWb5bEQppg8HdYwW3rBD2sPoS4UQHVajfaxBkqyzLeJ3wR0kZ+5xoTjItxXaF7eIXUsyw==",
 			"bundleDependencies": [
 				"@isaacs/string-locale-compare",
 				"@npmcli/arborist",
 				"@npmcli/config",
 				"@npmcli/fs",
 				"@npmcli/map-workspaces",
+				"@npmcli/metavuln-calculator",
 				"@npmcli/package-json",
 				"@npmcli/promise-spawn",
 				"@npmcli/redact",
@@ -6102,7 +6239,6 @@
 				"cacache",
 				"chalk",
 				"ci-info",
-				"cli-columns",
 				"fastest-levenshtein",
 				"fs-minipass",
 				"glob",
@@ -6116,7 +6252,6 @@
 				"libnpmdiff",
 				"libnpmexec",
 				"libnpmfund",
-				"libnpmhook",
 				"libnpmorg",
 				"libnpmpack",
 				"libnpmpublish",
@@ -6130,7 +6265,6 @@
 				"ms",
 				"node-gyp",
 				"nopt",
-				"normalize-package-data",
 				"npm-audit-report",
 				"npm-install-checks",
 				"npm-package-arg",
@@ -6153,8 +6287,7 @@
 				"tiny-relative-date",
 				"treeverse",
 				"validate-npm-package-name",
-				"which",
-				"write-file-atomic"
+				"which"
 			],
 			"dev": true,
 			"license": "Artistic-2.0",
@@ -6167,80 +6300,77 @@
 			],
 			"dependencies": {
 				"@isaacs/string-locale-compare": "^1.1.0",
-				"@npmcli/arborist": "^8.0.1",
-				"@npmcli/config": "^9.0.0",
-				"@npmcli/fs": "^4.0.0",
-				"@npmcli/map-workspaces": "^4.0.2",
-				"@npmcli/package-json": "^6.2.0",
-				"@npmcli/promise-spawn": "^8.0.2",
-				"@npmcli/redact": "^3.2.2",
-				"@npmcli/run-script": "^9.1.0",
-				"@sigstore/tuf": "^3.1.1",
-				"abbrev": "^3.0.1",
+				"@npmcli/arborist": "^9.7.0",
+				"@npmcli/config": "^10.10.0",
+				"@npmcli/fs": "^5.0.0",
+				"@npmcli/map-workspaces": "^5.0.3",
+				"@npmcli/metavuln-calculator": "^9.0.3",
+				"@npmcli/package-json": "^7.0.5",
+				"@npmcli/promise-spawn": "^9.0.1",
+				"@npmcli/redact": "^4.0.0",
+				"@npmcli/run-script": "^10.0.4",
+				"@sigstore/tuf": "^4.0.2",
+				"abbrev": "^4.0.0",
 				"archy": "~1.0.0",
-				"cacache": "^19.0.1",
-				"chalk": "^5.4.1",
-				"ci-info": "^4.2.0",
-				"cli-columns": "^4.0.0",
+				"cacache": "^20.0.4",
+				"chalk": "^5.6.2",
+				"ci-info": "^4.4.0",
 				"fastest-levenshtein": "^1.0.16",
 				"fs-minipass": "^3.0.3",
-				"glob": "^10.4.5",
+				"glob": "^13.0.6",
 				"graceful-fs": "^4.2.11",
-				"hosted-git-info": "^8.1.0",
-				"ini": "^5.0.0",
-				"init-package-json": "^7.0.2",
-				"is-cidr": "^5.1.1",
-				"json-parse-even-better-errors": "^4.0.0",
-				"libnpmaccess": "^9.0.0",
-				"libnpmdiff": "^7.0.1",
-				"libnpmexec": "^9.0.1",
-				"libnpmfund": "^6.0.1",
-				"libnpmhook": "^11.0.0",
-				"libnpmorg": "^7.0.0",
-				"libnpmpack": "^8.0.1",
-				"libnpmpublish": "^10.0.1",
-				"libnpmsearch": "^8.0.0",
-				"libnpmteam": "^7.0.0",
-				"libnpmversion": "^7.0.0",
-				"make-fetch-happen": "^14.0.3",
-				"minimatch": "^9.0.5",
-				"minipass": "^7.1.1",
+				"hosted-git-info": "^9.0.3",
+				"ini": "^6.0.0",
+				"init-package-json": "^8.2.5",
+				"is-cidr": "^6.0.4",
+				"json-parse-even-better-errors": "^5.0.0",
+				"libnpmaccess": "^10.0.3",
+				"libnpmdiff": "^8.1.9",
+				"libnpmexec": "^10.2.9",
+				"libnpmfund": "^7.0.23",
+				"libnpmorg": "^8.0.1",
+				"libnpmpack": "^9.1.9",
+				"libnpmpublish": "^11.2.0",
+				"libnpmsearch": "^9.0.1",
+				"libnpmteam": "^8.0.2",
+				"libnpmversion": "^8.0.4",
+				"make-fetch-happen": "^15.0.6",
+				"minimatch": "^10.2.5",
+				"minipass": "^7.1.3",
 				"minipass-pipeline": "^1.2.4",
 				"ms": "^2.1.2",
-				"node-gyp": "^11.2.0",
-				"nopt": "^8.1.0",
-				"normalize-package-data": "^7.0.0",
-				"npm-audit-report": "^6.0.0",
-				"npm-install-checks": "^7.1.1",
-				"npm-package-arg": "^12.0.2",
-				"npm-pick-manifest": "^10.0.0",
-				"npm-profile": "^11.0.1",
-				"npm-registry-fetch": "^18.0.2",
-				"npm-user-validate": "^3.0.0",
-				"p-map": "^7.0.3",
-				"pacote": "^19.0.1",
-				"parse-conflict-json": "^4.0.0",
-				"proc-log": "^5.0.0",
+				"node-gyp": "^12.3.0",
+				"nopt": "^9.0.0",
+				"npm-audit-report": "^7.0.0",
+				"npm-install-checks": "^8.0.0",
+				"npm-package-arg": "^13.0.2",
+				"npm-pick-manifest": "^11.0.3",
+				"npm-profile": "^12.0.1",
+				"npm-registry-fetch": "^19.1.1",
+				"npm-user-validate": "^4.0.0",
+				"p-map": "^7.0.4",
+				"pacote": "^21.5.0",
+				"parse-conflict-json": "^5.0.1",
+				"proc-log": "^6.1.0",
 				"qrcode-terminal": "^0.12.0",
-				"read": "^4.1.0",
-				"semver": "^7.7.2",
+				"read": "^5.0.1",
+				"semver": "^7.8.1",
 				"spdx-expression-parse": "^4.0.0",
-				"ssri": "^12.0.0",
-				"supports-color": "^9.4.0",
-				"tar": "^6.2.1",
+				"ssri": "^13.0.1",
+				"supports-color": "^10.2.2",
+				"tar": "^7.5.15",
 				"text-table": "~0.2.0",
-				"tiny-relative-date": "^1.3.0",
+				"tiny-relative-date": "^2.0.2",
 				"treeverse": "^3.0.0",
-				"validate-npm-package-name": "^6.0.1",
-				"which": "^5.0.0",
-				"write-file-atomic": "^6.0.0"
+				"validate-npm-package-name": "^7.0.2",
+				"which": "^6.0.1"
 			},
 			"bin": {
 				"npm": "bin/npm-cli.js",
 				"npx": "bin/npx-cli.js"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm-run-path": {
@@ -6273,71 +6403,13 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/npm/node_modules/@isaacs/cliui": {
-			"version": "8.0.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"string-width": "^5.1.2",
-				"string-width-cjs": "npm:string-width@^4.2.0",
-				"strip-ansi": "^7.0.1",
-				"strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-				"wrap-ansi": "^8.1.0",
-				"wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/npm/node_modules/@isaacs/cliui/node_modules/ansi-regex": {
-			"version": "6.1.0",
+		"node_modules/npm/node_modules/@gar/promise-retry": {
+			"version": "1.0.3",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
-			}
-		},
-		"node_modules/npm/node_modules/@isaacs/cliui/node_modules/emoji-regex": {
-			"version": "9.2.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT"
-		},
-		"node_modules/npm/node_modules/@isaacs/cliui/node_modules/string-width": {
-			"version": "5.1.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"eastasianwidth": "^0.2.0",
-				"emoji-regex": "^9.2.2",
-				"strip-ansi": "^7.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/npm/node_modules/@isaacs/cliui/node_modules/strip-ansi": {
-			"version": "7.1.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/@isaacs/fs-minipass": {
@@ -6359,7 +6431,7 @@
 			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/@npmcli/agent": {
-			"version": "3.0.0",
+			"version": "4.0.2",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -6367,83 +6439,82 @@
 				"agent-base": "^7.1.0",
 				"http-proxy-agent": "^7.0.0",
 				"https-proxy-agent": "^7.0.1",
-				"lru-cache": "^10.0.1",
+				"lru-cache": "^11.2.1",
 				"socks-proxy-agent": "^8.0.3"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/arborist": {
-			"version": "8.0.1",
+			"version": "9.7.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
+				"@gar/promise-retry": "^1.0.0",
 				"@isaacs/string-locale-compare": "^1.1.0",
-				"@npmcli/fs": "^4.0.0",
-				"@npmcli/installed-package-contents": "^3.0.0",
-				"@npmcli/map-workspaces": "^4.0.1",
-				"@npmcli/metavuln-calculator": "^8.0.0",
-				"@npmcli/name-from-folder": "^3.0.0",
-				"@npmcli/node-gyp": "^4.0.0",
-				"@npmcli/package-json": "^6.0.1",
-				"@npmcli/query": "^4.0.0",
-				"@npmcli/redact": "^3.0.0",
-				"@npmcli/run-script": "^9.0.1",
-				"bin-links": "^5.0.0",
-				"cacache": "^19.0.1",
-				"common-ancestor-path": "^1.0.1",
-				"hosted-git-info": "^8.0.0",
-				"json-parse-even-better-errors": "^4.0.0",
+				"@npmcli/fs": "^5.0.0",
+				"@npmcli/installed-package-contents": "^4.0.0",
+				"@npmcli/map-workspaces": "^5.0.0",
+				"@npmcli/metavuln-calculator": "^9.0.2",
+				"@npmcli/name-from-folder": "^4.0.0",
+				"@npmcli/node-gyp": "^5.0.0",
+				"@npmcli/package-json": "^7.0.0",
+				"@npmcli/query": "^5.0.0",
+				"@npmcli/redact": "^4.0.0",
+				"@npmcli/run-script": "^10.0.0",
+				"bin-links": "^6.0.0",
+				"cacache": "^20.0.1",
+				"common-ancestor-path": "^2.0.0",
+				"hosted-git-info": "^9.0.0",
 				"json-stringify-nice": "^1.1.4",
-				"lru-cache": "^10.2.2",
-				"minimatch": "^9.0.4",
-				"nopt": "^8.0.0",
-				"npm-install-checks": "^7.1.0",
-				"npm-package-arg": "^12.0.0",
-				"npm-pick-manifest": "^10.0.0",
-				"npm-registry-fetch": "^18.0.1",
-				"pacote": "^19.0.0",
-				"parse-conflict-json": "^4.0.0",
-				"proc-log": "^5.0.0",
-				"proggy": "^3.0.0",
+				"lru-cache": "^11.2.1",
+				"minimatch": "^10.0.3",
+				"nopt": "^9.0.0",
+				"npm-install-checks": "^8.0.0",
+				"npm-package-arg": "^13.0.0",
+				"npm-pick-manifest": "^11.0.1",
+				"npm-registry-fetch": "^19.0.0",
+				"pacote": "^21.0.2",
+				"parse-conflict-json": "^5.0.1",
+				"proc-log": "^6.0.0",
+				"proggy": "^4.0.0",
 				"promise-all-reject-late": "^1.0.0",
 				"promise-call-limit": "^3.0.1",
-				"read-package-json-fast": "^4.0.0",
 				"semver": "^7.3.7",
-				"ssri": "^12.0.0",
+				"ssri": "^13.0.0",
 				"treeverse": "^3.0.0",
-				"walk-up-path": "^3.0.1"
+				"walk-up-path": "^4.0.0"
 			},
 			"bin": {
 				"arborist": "bin/index.js"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/config": {
-			"version": "9.0.0",
+			"version": "10.10.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/map-workspaces": "^4.0.1",
-				"@npmcli/package-json": "^6.0.1",
+				"@npmcli/map-workspaces": "^5.0.0",
+				"@npmcli/package-json": "^7.0.0",
 				"ci-info": "^4.0.0",
-				"ini": "^5.0.0",
-				"nopt": "^8.0.0",
-				"proc-log": "^5.0.0",
+				"ini": "^6.0.0",
+				"nopt": "^9.0.0",
+				"proc-log": "^6.0.0",
 				"semver": "^7.3.5",
-				"walk-up-path": "^3.0.1"
+				"walk-up-path": "^4.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/fs": {
-			"version": "4.0.0",
+			"version": "5.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -6451,156 +6522,125 @@
 				"semver": "^7.3.5"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/git": {
-			"version": "6.0.3",
+			"version": "7.0.2",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/promise-spawn": "^8.0.0",
-				"ini": "^5.0.0",
-				"lru-cache": "^10.0.1",
-				"npm-pick-manifest": "^10.0.0",
-				"proc-log": "^5.0.0",
-				"promise-retry": "^2.0.1",
+				"@gar/promise-retry": "^1.0.0",
+				"@npmcli/promise-spawn": "^9.0.0",
+				"ini": "^6.0.0",
+				"lru-cache": "^11.2.1",
+				"npm-pick-manifest": "^11.0.1",
+				"proc-log": "^6.0.0",
 				"semver": "^7.3.5",
-				"which": "^5.0.0"
+				"which": "^6.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/installed-package-contents": {
-			"version": "3.0.0",
+			"version": "4.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"npm-bundled": "^4.0.0",
-				"npm-normalize-package-bin": "^4.0.0"
+				"npm-bundled": "^5.0.0",
+				"npm-normalize-package-bin": "^5.0.0"
 			},
 			"bin": {
 				"installed-package-contents": "bin/index.js"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/map-workspaces": {
-			"version": "4.0.2",
+			"version": "5.0.3",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/name-from-folder": "^3.0.0",
-				"@npmcli/package-json": "^6.0.0",
-				"glob": "^10.2.2",
-				"minimatch": "^9.0.0"
+				"@npmcli/name-from-folder": "^4.0.0",
+				"@npmcli/package-json": "^7.0.0",
+				"glob": "^13.0.0",
+				"minimatch": "^10.0.3"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
-			"version": "8.0.1",
+			"version": "9.0.3",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"cacache": "^19.0.0",
-				"json-parse-even-better-errors": "^4.0.0",
-				"pacote": "^20.0.0",
-				"proc-log": "^5.0.0",
+				"cacache": "^20.0.0",
+				"json-parse-even-better-errors": "^5.0.0",
+				"pacote": "^21.0.0",
+				"proc-log": "^6.0.0",
 				"semver": "^7.3.5"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/npm/node_modules/@npmcli/metavuln-calculator/node_modules/pacote": {
-			"version": "20.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"@npmcli/git": "^6.0.0",
-				"@npmcli/installed-package-contents": "^3.0.0",
-				"@npmcli/package-json": "^6.0.0",
-				"@npmcli/promise-spawn": "^8.0.0",
-				"@npmcli/run-script": "^9.0.0",
-				"cacache": "^19.0.0",
-				"fs-minipass": "^3.0.0",
-				"minipass": "^7.0.2",
-				"npm-package-arg": "^12.0.0",
-				"npm-packlist": "^9.0.0",
-				"npm-pick-manifest": "^10.0.0",
-				"npm-registry-fetch": "^18.0.0",
-				"proc-log": "^5.0.0",
-				"promise-retry": "^2.0.1",
-				"sigstore": "^3.0.0",
-				"ssri": "^12.0.0",
-				"tar": "^6.1.11"
-			},
-			"bin": {
-				"pacote": "bin/index.js"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/name-from-folder": {
-			"version": "3.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/npm/node_modules/@npmcli/node-gyp": {
 			"version": "4.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/node-gyp": {
+			"version": "5.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/package-json": {
-			"version": "6.2.0",
+			"version": "7.0.5",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/git": "^6.0.0",
-				"glob": "^10.2.2",
-				"hosted-git-info": "^8.0.0",
-				"json-parse-even-better-errors": "^4.0.0",
-				"proc-log": "^5.0.0",
+				"@npmcli/git": "^7.0.0",
+				"glob": "^13.0.0",
+				"hosted-git-info": "^9.0.0",
+				"json-parse-even-better-errors": "^5.0.0",
+				"proc-log": "^6.0.0",
 				"semver": "^7.5.3",
-				"validate-npm-package-license": "^3.0.4"
+				"spdx-expression-parse": "^4.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/promise-spawn": {
-			"version": "8.0.2",
+			"version": "9.0.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"which": "^5.0.0"
+				"which": "^6.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/query": {
-			"version": "4.0.1",
+			"version": "5.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -6608,47 +6648,57 @@
 				"postcss-selector-parser": "^7.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/redact": {
-			"version": "3.2.2",
+			"version": "4.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/run-script": {
-			"version": "9.1.0",
+			"version": "10.0.4",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/node-gyp": "^4.0.0",
-				"@npmcli/package-json": "^6.0.0",
-				"@npmcli/promise-spawn": "^8.0.0",
-				"node-gyp": "^11.0.0",
-				"proc-log": "^5.0.0",
-				"which": "^5.0.0"
+				"@npmcli/node-gyp": "^5.0.0",
+				"@npmcli/package-json": "^7.0.0",
+				"@npmcli/promise-spawn": "^9.0.0",
+				"node-gyp": "^12.1.0",
+				"proc-log": "^6.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
-		"node_modules/npm/node_modules/@pkgjs/parseargs": {
-			"version": "0.11.0",
+		"node_modules/npm/node_modules/@sigstore/bundle": {
+			"version": "4.0.0",
 			"dev": true,
 			"inBundle": true,
-			"license": "MIT",
-			"optional": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@sigstore/protobuf-specs": "^0.5.0"
+			},
 			"engines": {
-				"node": ">=14"
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/@sigstore/core": {
+			"version": "3.2.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/@sigstore/protobuf-specs": {
-			"version": "0.4.3",
+			"version": "0.5.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "Apache-2.0",
@@ -6656,17 +6706,48 @@
 				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
+		"node_modules/npm/node_modules/@sigstore/sign": {
+			"version": "4.1.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@gar/promise-retry": "^1.0.2",
+				"@sigstore/bundle": "^4.0.0",
+				"@sigstore/core": "^3.2.0",
+				"@sigstore/protobuf-specs": "^0.5.0",
+				"make-fetch-happen": "^15.0.4",
+				"proc-log": "^6.1.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
 		"node_modules/npm/node_modules/@sigstore/tuf": {
+			"version": "4.0.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@sigstore/protobuf-specs": "^0.5.0",
+				"tuf-js": "^4.1.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/@sigstore/verify": {
 			"version": "3.1.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@sigstore/protobuf-specs": "^0.4.1",
-				"tuf-js": "^3.0.1"
+				"@sigstore/bundle": "^4.0.0",
+				"@sigstore/core": "^3.2.1",
+				"@sigstore/protobuf-specs": "^0.5.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/@tufjs/canonical-json": {
@@ -6678,17 +6759,30 @@
 				"node": "^16.14.0 || >=18.0.0"
 			}
 		},
+		"node_modules/npm/node_modules/@tufjs/models": {
+			"version": "4.1.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"@tufjs/canonical-json": "2.0.0",
+				"minimatch": "^10.1.1"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
 		"node_modules/npm/node_modules/abbrev": {
-			"version": "3.0.1",
+			"version": "4.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/agent-base": {
-			"version": "7.1.3",
+			"version": "7.1.4",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
@@ -6696,29 +6790,8 @@
 				"node": ">= 14"
 			}
 		},
-		"node_modules/npm/node_modules/ansi-regex": {
-			"version": "5.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/npm/node_modules/ansi-styles": {
-			"version": "6.2.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
 		"node_modules/npm/node_modules/aproba": {
-			"version": "2.0.0",
+			"version": "2.1.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC"
@@ -6730,123 +6803,77 @@
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/balanced-match": {
-			"version": "1.0.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT"
-		},
-		"node_modules/npm/node_modules/bin-links": {
-			"version": "5.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"cmd-shim": "^7.0.0",
-				"npm-normalize-package-bin": "^4.0.0",
-				"proc-log": "^5.0.0",
-				"read-cmd-shim": "^5.0.0",
-				"write-file-atomic": "^6.0.0"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/npm/node_modules/binary-extensions": {
-			"version": "2.3.0",
+			"version": "4.0.4",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=8"
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/npm/node_modules/bin-links": {
+			"version": "6.0.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"cmd-shim": "^8.0.0",
+				"npm-normalize-package-bin": "^5.0.0",
+				"proc-log": "^6.0.0",
+				"read-cmd-shim": "^6.0.0",
+				"write-file-atomic": "^7.0.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/binary-extensions": {
+			"version": "3.1.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/npm/node_modules/brace-expansion": {
-			"version": "2.0.2",
+			"version": "5.0.6",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
-				"balanced-match": "^1.0.0"
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
 			}
 		},
 		"node_modules/npm/node_modules/cacache": {
-			"version": "19.0.1",
+			"version": "20.0.4",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/fs": "^4.0.0",
+				"@npmcli/fs": "^5.0.0",
 				"fs-minipass": "^3.0.0",
-				"glob": "^10.2.2",
-				"lru-cache": "^10.0.1",
+				"glob": "^13.0.0",
+				"lru-cache": "^11.1.0",
 				"minipass": "^7.0.3",
 				"minipass-collect": "^2.0.1",
 				"minipass-flush": "^1.0.5",
 				"minipass-pipeline": "^1.2.4",
 				"p-map": "^7.0.2",
-				"ssri": "^12.0.0",
-				"tar": "^7.4.3",
-				"unique-filename": "^4.0.0"
+				"ssri": "^13.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/npm/node_modules/cacache/node_modules/chownr": {
-			"version": "3.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/npm/node_modules/cacache/node_modules/mkdirp": {
-			"version": "3.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"bin": {
-				"mkdirp": "dist/cjs/src/bin.js"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/npm/node_modules/cacache/node_modules/tar": {
-			"version": "7.4.3",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"@isaacs/fs-minipass": "^4.0.0",
-				"chownr": "^3.0.0",
-				"minipass": "^7.1.2",
-				"minizlib": "^3.0.1",
-				"mkdirp": "^3.0.1",
-				"yallist": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/npm/node_modules/cacache/node_modules/yallist": {
-			"version": "5.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">=18"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/chalk": {
-			"version": "5.4.1",
+			"version": "5.6.2",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
@@ -6858,16 +6885,16 @@
 			}
 		},
 		"node_modules/npm/node_modules/chownr": {
-			"version": "2.0.0",
+			"version": "3.0.0",
 			"dev": true,
 			"inBundle": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"engines": {
-				"node": ">=10"
+				"node": ">=18"
 			}
 		},
 		"node_modules/npm/node_modules/ci-info": {
-			"version": "4.2.0",
+			"version": "4.4.0",
 			"dev": true,
 			"funding": [
 				{
@@ -6882,90 +6909,30 @@
 			}
 		},
 		"node_modules/npm/node_modules/cidr-regex": {
-			"version": "4.1.3",
+			"version": "5.0.5",
 			"dev": true,
 			"inBundle": true,
 			"license": "BSD-2-Clause",
-			"dependencies": {
-				"ip-regex": "^5.0.0"
-			},
 			"engines": {
-				"node": ">=14"
-			}
-		},
-		"node_modules/npm/node_modules/cli-columns": {
-			"version": "4.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"string-width": "^4.2.3",
-				"strip-ansi": "^6.0.1"
-			},
-			"engines": {
-				"node": ">= 10"
+				"node": ">=20"
 			}
 		},
 		"node_modules/npm/node_modules/cmd-shim": {
-			"version": "7.0.0",
+			"version": "8.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
-		},
-		"node_modules/npm/node_modules/color-convert": {
-			"version": "2.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"color-name": "~1.1.4"
-			},
-			"engines": {
-				"node": ">=7.0.0"
-			}
-		},
-		"node_modules/npm/node_modules/color-name": {
-			"version": "1.1.4",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/common-ancestor-path": {
-			"version": "1.0.1",
+			"version": "2.0.0",
 			"dev": true,
 			"inBundle": true,
-			"license": "ISC"
-		},
-		"node_modules/npm/node_modules/cross-spawn": {
-			"version": "7.0.6",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"path-key": "^3.1.0",
-				"shebang-command": "^2.0.0",
-				"which": "^2.0.1"
-			},
+			"license": "BlueOak-1.0.0",
 			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/npm/node_modules/cross-spawn/node_modules/which": {
-			"version": "2.0.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"isexe": "^2.0.0"
-			},
-			"bin": {
-				"node-which": "bin/node-which"
-			},
-			"engines": {
-				"node": ">= 8"
+				"node": ">= 18"
 			}
 		},
 		"node_modules/npm/node_modules/cssesc": {
@@ -6981,7 +6948,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/debug": {
-			"version": "4.4.1",
+			"version": "4.4.3",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
@@ -6998,34 +6965,12 @@
 			}
 		},
 		"node_modules/npm/node_modules/diff": {
-			"version": "5.2.0",
+			"version": "8.0.4",
 			"dev": true,
 			"inBundle": true,
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.3.1"
-			}
-		},
-		"node_modules/npm/node_modules/eastasianwidth": {
-			"version": "0.2.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT"
-		},
-		"node_modules/npm/node_modules/emoji-regex": {
-			"version": "8.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT"
-		},
-		"node_modules/npm/node_modules/encoding": {
-			"version": "0.1.13",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"iconv-lite": "^0.6.2"
 			}
 		},
 		"node_modules/npm/node_modules/env-paths": {
@@ -7037,14 +6982,8 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/npm/node_modules/err-code": {
-			"version": "2.0.3",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT"
-		},
 		"node_modules/npm/node_modules/exponential-backoff": {
-			"version": "3.1.2",
+			"version": "3.1.3",
 			"dev": true,
 			"inBundle": true,
 			"license": "Apache-2.0"
@@ -7056,22 +6995,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 4.9.1"
-			}
-		},
-		"node_modules/npm/node_modules/foreground-child": {
-			"version": "3.3.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"cross-spawn": "^7.0.6",
-				"signal-exit": "^4.0.1"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/npm/node_modules/fs-minipass": {
@@ -7087,20 +7010,17 @@
 			}
 		},
 		"node_modules/npm/node_modules/glob": {
-			"version": "10.4.5",
+			"version": "13.0.6",
 			"dev": true,
 			"inBundle": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"foreground-child": "^3.1.0",
-				"jackspeak": "^3.1.2",
-				"minimatch": "^9.0.4",
-				"minipass": "^7.1.2",
-				"package-json-from-dist": "^1.0.0",
-				"path-scurry": "^1.11.1"
+				"minimatch": "^10.2.2",
+				"minipass": "^7.1.3",
+				"path-scurry": "^2.0.2"
 			},
-			"bin": {
-				"glob": "dist/esm/bin.mjs"
+			"engines": {
+				"node": "18 || 20 || >=22"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
@@ -7113,15 +7033,15 @@
 			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/hosted-git-info": {
-			"version": "8.1.0",
+			"version": "9.0.3",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"lru-cache": "^10.0.1"
+				"lru-cache": "^11.1.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/http-cache-semantics": {
@@ -7157,7 +7077,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/iconv-lite": {
-			"version": "0.6.3",
+			"version": "0.7.2",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
@@ -7167,136 +7087,87 @@
 			},
 			"engines": {
 				"node": ">=0.10.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/npm/node_modules/ignore-walk": {
-			"version": "7.0.0",
+			"version": "8.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"minimatch": "^9.0.0"
+				"minimatch": "^10.0.3"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/npm/node_modules/imurmurhash": {
-			"version": "0.1.4",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.8.19"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/ini": {
-			"version": "5.0.0",
+			"version": "6.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/init-package-json": {
-			"version": "7.0.2",
+			"version": "8.2.5",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/package-json": "^6.0.0",
-				"npm-package-arg": "^12.0.0",
-				"promzard": "^2.0.0",
-				"read": "^4.0.0",
-				"semver": "^7.3.5",
-				"validate-npm-package-license": "^3.0.4",
-				"validate-npm-package-name": "^6.0.0"
+				"@npmcli/package-json": "^7.0.0",
+				"npm-package-arg": "^13.0.0",
+				"promzard": "^3.0.1",
+				"read": "^5.0.1",
+				"semver": "^7.7.2",
+				"validate-npm-package-name": "^7.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/ip-address": {
-			"version": "9.0.5",
+			"version": "10.2.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"dependencies": {
-				"jsbn": "1.1.0",
-				"sprintf-js": "^1.1.3"
-			},
 			"engines": {
 				"node": ">= 12"
 			}
 		},
-		"node_modules/npm/node_modules/ip-regex": {
+		"node_modules/npm/node_modules/is-cidr": {
+			"version": "6.0.4",
+			"dev": true,
+			"inBundle": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"cidr-regex": "^5.0.4"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/npm/node_modules/isexe": {
+			"version": "4.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/npm/node_modules/json-parse-even-better-errors": {
 			"version": "5.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/npm/node_modules/is-cidr": {
-			"version": "5.1.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"cidr-regex": "^4.1.1"
-			},
-			"engines": {
-				"node": ">=14"
-			}
-		},
-		"node_modules/npm/node_modules/is-fullwidth-code-point": {
-			"version": "3.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/npm/node_modules/isexe": {
-			"version": "2.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC"
-		},
-		"node_modules/npm/node_modules/jackspeak": {
-			"version": "3.4.3",
-			"dev": true,
-			"inBundle": true,
-			"license": "BlueOak-1.0.0",
-			"dependencies": {
-				"@isaacs/cliui": "^8.0.2"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			},
-			"optionalDependencies": {
-				"@pkgjs/parseargs": "^0.11.0"
-			}
-		},
-		"node_modules/npm/node_modules/jsbn": {
-			"version": "1.1.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT"
-		},
-		"node_modules/npm/node_modules/json-parse-even-better-errors": {
-			"version": "4.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/json-stringify-nice": {
@@ -7330,228 +7201,212 @@
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/libnpmaccess": {
-			"version": "9.0.0",
+			"version": "10.0.3",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"npm-package-arg": "^12.0.0",
-				"npm-registry-fetch": "^18.0.1"
+				"npm-package-arg": "^13.0.0",
+				"npm-registry-fetch": "^19.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/libnpmdiff": {
-			"version": "7.0.1",
+			"version": "8.1.9",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/arborist": "^8.0.1",
-				"@npmcli/installed-package-contents": "^3.0.0",
-				"binary-extensions": "^2.3.0",
-				"diff": "^5.1.0",
-				"minimatch": "^9.0.4",
-				"npm-package-arg": "^12.0.0",
-				"pacote": "^19.0.0",
-				"tar": "^6.2.1"
+				"@npmcli/arborist": "^9.7.0",
+				"@npmcli/installed-package-contents": "^4.0.0",
+				"binary-extensions": "^3.0.0",
+				"diff": "^8.0.2",
+				"minimatch": "^10.0.3",
+				"npm-package-arg": "^13.0.0",
+				"pacote": "^21.0.2",
+				"tar": "^7.5.1"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/libnpmexec": {
-			"version": "9.0.1",
+			"version": "10.2.9",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/arborist": "^8.0.1",
-				"@npmcli/run-script": "^9.0.1",
+				"@gar/promise-retry": "^1.0.0",
+				"@npmcli/arborist": "^9.7.0",
+				"@npmcli/package-json": "^7.0.0",
+				"@npmcli/run-script": "^10.0.0",
 				"ci-info": "^4.0.0",
-				"npm-package-arg": "^12.0.0",
-				"pacote": "^19.0.0",
-				"proc-log": "^5.0.0",
-				"read": "^4.0.0",
-				"read-package-json-fast": "^4.0.0",
+				"npm-package-arg": "^13.0.0",
+				"pacote": "^21.0.2",
+				"proc-log": "^6.0.0",
+				"read": "^5.0.1",
 				"semver": "^7.3.7",
-				"walk-up-path": "^3.0.1"
+				"signal-exit": "^4.1.0",
+				"walk-up-path": "^4.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/libnpmfund": {
-			"version": "6.0.1",
+			"version": "7.0.23",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/arborist": "^8.0.1"
+				"@npmcli/arborist": "^9.7.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/npm/node_modules/libnpmhook": {
-			"version": "11.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"aproba": "^2.0.0",
-				"npm-registry-fetch": "^18.0.1"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/libnpmorg": {
-			"version": "7.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"aproba": "^2.0.0",
-				"npm-registry-fetch": "^18.0.1"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/npm/node_modules/libnpmpack": {
 			"version": "8.0.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/arborist": "^8.0.1",
-				"@npmcli/run-script": "^9.0.1",
-				"npm-package-arg": "^12.0.0",
-				"pacote": "^19.0.0"
+				"aproba": "^2.0.0",
+				"npm-registry-fetch": "^19.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/libnpmpack": {
+			"version": "9.1.9",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/arborist": "^9.7.0",
+				"@npmcli/run-script": "^10.0.0",
+				"npm-package-arg": "^13.0.0",
+				"pacote": "^21.0.2"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/libnpmpublish": {
-			"version": "10.0.1",
+			"version": "11.2.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
+				"@npmcli/package-json": "^7.0.0",
 				"ci-info": "^4.0.0",
-				"normalize-package-data": "^7.0.0",
-				"npm-package-arg": "^12.0.0",
-				"npm-registry-fetch": "^18.0.1",
-				"proc-log": "^5.0.0",
+				"npm-package-arg": "^13.0.0",
+				"npm-registry-fetch": "^19.0.0",
+				"proc-log": "^6.0.0",
 				"semver": "^7.3.7",
-				"sigstore": "^3.0.0",
-				"ssri": "^12.0.0"
+				"sigstore": "^4.0.0",
+				"ssri": "^13.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/libnpmsearch": {
-			"version": "8.0.0",
+			"version": "9.0.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"npm-registry-fetch": "^18.0.1"
+				"npm-registry-fetch": "^19.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/libnpmteam": {
-			"version": "7.0.0",
+			"version": "8.0.2",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"aproba": "^2.0.0",
-				"npm-registry-fetch": "^18.0.1"
+				"npm-registry-fetch": "^19.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/libnpmversion": {
-			"version": "7.0.0",
+			"version": "8.0.4",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/git": "^6.0.1",
-				"@npmcli/run-script": "^9.0.1",
-				"json-parse-even-better-errors": "^4.0.0",
-				"proc-log": "^5.0.0",
+				"@npmcli/git": "^7.0.0",
+				"@npmcli/run-script": "^10.0.0",
+				"json-parse-even-better-errors": "^5.0.0",
+				"proc-log": "^6.0.0",
 				"semver": "^7.3.7"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/lru-cache": {
-			"version": "10.4.3",
+			"version": "11.5.1",
 			"dev": true,
 			"inBundle": true,
-			"license": "ISC"
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
+			}
 		},
 		"node_modules/npm/node_modules/make-fetch-happen": {
-			"version": "14.0.3",
+			"version": "15.0.6",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/agent": "^3.0.0",
-				"cacache": "^19.0.1",
+				"@gar/promise-retry": "^1.0.0",
+				"@npmcli/agent": "^4.0.0",
+				"@npmcli/redact": "^4.0.0",
+				"cacache": "^20.0.1",
 				"http-cache-semantics": "^4.1.1",
 				"minipass": "^7.0.2",
-				"minipass-fetch": "^4.0.0",
+				"minipass-fetch": "^5.0.0",
 				"minipass-flush": "^1.0.5",
 				"minipass-pipeline": "^1.2.4",
 				"negotiator": "^1.0.0",
-				"proc-log": "^5.0.0",
-				"promise-retry": "^2.0.1",
-				"ssri": "^12.0.0"
+				"proc-log": "^6.0.0",
+				"ssri": "^13.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/npm/node_modules/make-fetch-happen/node_modules/negotiator": {
-			"version": "1.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/minimatch": {
-			"version": "9.0.5",
+			"version": "10.2.5",
 			"dev": true,
 			"inBundle": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"brace-expansion": "^2.0.1"
+				"brace-expansion": "^5.0.5"
 			},
 			"engines": {
-				"node": ">=16 || 14 >=14.17"
+				"node": "18 || 20 || >=22"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/npm/node_modules/minipass": {
-			"version": "7.1.2",
+			"version": "7.1.3",
 			"dev": true,
 			"inBundle": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
 			}
@@ -7569,44 +7424,32 @@
 			}
 		},
 		"node_modules/npm/node_modules/minipass-fetch": {
-			"version": "4.0.1",
+			"version": "5.0.2",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
 				"minipass": "^7.0.3",
-				"minipass-sized": "^1.0.3",
+				"minipass-sized": "^2.0.0",
 				"minizlib": "^3.0.1"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			},
 			"optionalDependencies": {
-				"encoding": "^0.1.13"
+				"iconv-lite": "^0.7.2"
 			}
 		},
 		"node_modules/npm/node_modules/minipass-flush": {
-			"version": "1.0.5",
+			"version": "1.0.6",
 			"dev": true,
 			"inBundle": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"minipass": "^3.0.0"
+				"minipass": "^7.1.3"
 			},
 			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/npm/node_modules/minipass-flush/node_modules/minipass": {
-			"version": "3.3.6",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
+				"node": ">=16 || 14 >=14.17"
 			}
 		},
 		"node_modules/npm/node_modules/minipass-pipeline": {
@@ -7633,32 +7476,26 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/npm/node_modules/minipass-sized": {
-			"version": "1.0.3",
+		"node_modules/npm/node_modules/minipass-pipeline/node_modules/yallist": {
+			"version": "4.0.0",
 			"dev": true,
 			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"minipass": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
+			"license": "ISC"
 		},
-		"node_modules/npm/node_modules/minipass-sized/node_modules/minipass": {
-			"version": "3.3.6",
+		"node_modules/npm/node_modules/minipass-sized": {
+			"version": "2.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"yallist": "^4.0.0"
+				"minipass": "^7.1.2"
 			},
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/npm/node_modules/minizlib": {
-			"version": "3.0.2",
+			"version": "3.1.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
@@ -7669,18 +7506,6 @@
 				"node": ">= 18"
 			}
 		},
-		"node_modules/npm/node_modules/mkdirp": {
-			"version": "1.0.4",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"bin": {
-				"mkdirp": "bin/cmd.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/npm/node_modules/ms": {
 			"version": "2.1.3",
 			"dev": true,
@@ -7688,16 +7513,25 @@
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/mute-stream": {
-			"version": "2.0.0",
+			"version": "3.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/npm/node_modules/negotiator": {
+			"version": "1.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
 			}
 		},
 		"node_modules/npm/node_modules/node-gyp": {
-			"version": "11.2.0",
+			"version": "12.3.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
@@ -7705,123 +7539,59 @@
 				"env-paths": "^2.2.0",
 				"exponential-backoff": "^3.1.1",
 				"graceful-fs": "^4.2.6",
-				"make-fetch-happen": "^14.0.3",
-				"nopt": "^8.0.0",
-				"proc-log": "^5.0.0",
+				"nopt": "^9.0.0",
+				"proc-log": "^6.0.0",
 				"semver": "^7.3.5",
-				"tar": "^7.4.3",
+				"tar": "^7.5.4",
 				"tinyglobby": "^0.2.12",
-				"which": "^5.0.0"
+				"undici": "^6.25.0",
+				"which": "^6.0.0"
 			},
 			"bin": {
 				"node-gyp": "bin/node-gyp.js"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/npm/node_modules/node-gyp/node_modules/chownr": {
-			"version": "3.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/npm/node_modules/node-gyp/node_modules/mkdirp": {
-			"version": "3.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"bin": {
-				"mkdirp": "dist/cjs/src/bin.js"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/npm/node_modules/node-gyp/node_modules/tar": {
-			"version": "7.4.3",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"@isaacs/fs-minipass": "^4.0.0",
-				"chownr": "^3.0.0",
-				"minipass": "^7.1.2",
-				"minizlib": "^3.0.1",
-				"mkdirp": "^3.0.1",
-				"yallist": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/npm/node_modules/node-gyp/node_modules/yallist": {
-			"version": "5.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "BlueOak-1.0.0",
-			"engines": {
-				"node": ">=18"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/nopt": {
-			"version": "8.1.0",
+			"version": "9.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"abbrev": "^3.0.0"
+				"abbrev": "^4.0.0"
 			},
 			"bin": {
 				"nopt": "bin/nopt.js"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/npm/node_modules/normalize-package-data": {
-			"version": "7.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"hosted-git-info": "^8.0.0",
-				"semver": "^7.3.5",
-				"validate-npm-package-license": "^3.0.4"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/npm-audit-report": {
-			"version": "6.0.0",
+			"version": "7.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/npm-bundled": {
-			"version": "4.0.0",
+			"version": "5.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"npm-normalize-package-bin": "^4.0.0"
+				"npm-normalize-package-bin": "^5.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/npm-install-checks": {
-			"version": "7.1.1",
+			"version": "8.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "BSD-2-Clause",
@@ -7829,103 +7599,104 @@
 				"semver": "^7.1.1"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/npm-normalize-package-bin": {
-			"version": "4.0.0",
+			"version": "5.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/npm-package-arg": {
-			"version": "12.0.2",
+			"version": "13.0.2",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"hosted-git-info": "^8.0.0",
-				"proc-log": "^5.0.0",
+				"hosted-git-info": "^9.0.0",
+				"proc-log": "^6.0.0",
 				"semver": "^7.3.5",
-				"validate-npm-package-name": "^6.0.0"
+				"validate-npm-package-name": "^7.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/npm-packlist": {
-			"version": "9.0.0",
+			"version": "10.0.4",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"ignore-walk": "^7.0.0"
+				"ignore-walk": "^8.0.0",
+				"proc-log": "^6.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/npm-pick-manifest": {
-			"version": "10.0.0",
+			"version": "11.0.3",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"npm-install-checks": "^7.1.0",
-				"npm-normalize-package-bin": "^4.0.0",
-				"npm-package-arg": "^12.0.0",
+				"npm-install-checks": "^8.0.0",
+				"npm-normalize-package-bin": "^5.0.0",
+				"npm-package-arg": "^13.0.0",
 				"semver": "^7.3.5"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/npm-profile": {
-			"version": "11.0.1",
+			"version": "12.0.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"npm-registry-fetch": "^18.0.0",
-				"proc-log": "^5.0.0"
+				"npm-registry-fetch": "^19.0.0",
+				"proc-log": "^6.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/npm-registry-fetch": {
-			"version": "18.0.2",
+			"version": "19.1.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/redact": "^3.0.0",
+				"@npmcli/redact": "^4.0.0",
 				"jsonparse": "^1.3.1",
-				"make-fetch-happen": "^14.0.0",
+				"make-fetch-happen": "^15.0.0",
 				"minipass": "^7.0.2",
-				"minipass-fetch": "^4.0.0",
+				"minipass-fetch": "^5.0.0",
 				"minizlib": "^3.0.1",
-				"npm-package-arg": "^12.0.0",
-				"proc-log": "^5.0.0"
+				"npm-package-arg": "^13.0.0",
+				"proc-log": "^6.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/npm-user-validate": {
-			"version": "3.0.0",
+			"version": "4.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "BSD-2-Clause",
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/p-map": {
-			"version": "7.0.3",
+			"version": "7.0.4",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
@@ -7936,84 +7707,69 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/npm/node_modules/package-json-from-dist": {
-			"version": "1.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "BlueOak-1.0.0"
-		},
 		"node_modules/npm/node_modules/pacote": {
-			"version": "19.0.1",
+			"version": "21.5.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/git": "^6.0.0",
-				"@npmcli/installed-package-contents": "^3.0.0",
-				"@npmcli/package-json": "^6.0.0",
-				"@npmcli/promise-spawn": "^8.0.0",
-				"@npmcli/run-script": "^9.0.0",
-				"cacache": "^19.0.0",
+				"@gar/promise-retry": "^1.0.0",
+				"@npmcli/git": "^7.0.0",
+				"@npmcli/installed-package-contents": "^4.0.0",
+				"@npmcli/package-json": "^7.0.0",
+				"@npmcli/promise-spawn": "^9.0.0",
+				"@npmcli/run-script": "^10.0.0",
+				"cacache": "^20.0.0",
 				"fs-minipass": "^3.0.0",
 				"minipass": "^7.0.2",
-				"npm-package-arg": "^12.0.0",
-				"npm-packlist": "^9.0.0",
-				"npm-pick-manifest": "^10.0.0",
-				"npm-registry-fetch": "^18.0.0",
-				"proc-log": "^5.0.0",
-				"promise-retry": "^2.0.1",
-				"sigstore": "^3.0.0",
-				"ssri": "^12.0.0",
-				"tar": "^6.1.11"
+				"npm-package-arg": "^13.0.0",
+				"npm-packlist": "^10.0.1",
+				"npm-pick-manifest": "^11.0.1",
+				"npm-registry-fetch": "^19.0.0",
+				"proc-log": "^6.0.0",
+				"sigstore": "^4.0.0",
+				"ssri": "^13.0.0",
+				"tar": "^7.4.3"
 			},
 			"bin": {
 				"pacote": "bin/index.js"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/parse-conflict-json": {
-			"version": "4.0.0",
+			"version": "5.0.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"json-parse-even-better-errors": "^4.0.0",
+				"json-parse-even-better-errors": "^5.0.0",
 				"just-diff": "^6.0.0",
 				"just-diff-apply": "^5.2.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/npm/node_modules/path-key": {
-			"version": "3.1.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/path-scurry": {
-			"version": "1.11.1",
+			"version": "2.0.2",
 			"dev": true,
 			"inBundle": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"lru-cache": "^10.2.0",
-				"minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+				"lru-cache": "^11.0.0",
+				"minipass": "^7.1.2"
 			},
 			"engines": {
-				"node": ">=16 || 14 >=14.18"
+				"node": "18 || 20 || >=22"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/npm/node_modules/postcss-selector-parser": {
-			"version": "7.1.0",
+			"version": "7.1.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
@@ -8026,21 +7782,21 @@
 			}
 		},
 		"node_modules/npm/node_modules/proc-log": {
-			"version": "5.0.0",
+			"version": "6.1.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/proggy": {
-			"version": "3.0.0",
+			"version": "4.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/promise-all-reject-late": {
@@ -8061,29 +7817,16 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/npm/node_modules/promise-retry": {
-			"version": "2.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"err-code": "^2.0.2",
-				"retry": "^0.12.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/npm/node_modules/promzard": {
-			"version": "2.0.0",
+			"version": "3.0.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"read": "^4.0.0"
+				"read": "^5.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/qrcode-terminal": {
@@ -8095,46 +7838,24 @@
 			}
 		},
 		"node_modules/npm/node_modules/read": {
-			"version": "4.1.0",
+			"version": "5.0.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"mute-stream": "^2.0.0"
+				"mute-stream": "^3.0.0"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/read-cmd-shim": {
-			"version": "5.0.0",
+			"version": "6.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/npm/node_modules/read-package-json-fast": {
-			"version": "4.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"json-parse-even-better-errors": "^4.0.0",
-				"npm-normalize-package-bin": "^4.0.0"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/npm/node_modules/retry": {
-			"version": "0.12.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 4"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/safer-buffer": {
@@ -8145,7 +7866,7 @@
 			"optional": true
 		},
 		"node_modules/npm/node_modules/semver": {
-			"version": "7.7.2",
+			"version": "7.8.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -8154,27 +7875,6 @@
 			},
 			"engines": {
 				"node": ">=10"
-			}
-		},
-		"node_modules/npm/node_modules/shebang-command": {
-			"version": "2.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"shebang-regex": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/npm/node_modules/shebang-regex": {
-			"version": "3.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/npm/node_modules/signal-exit": {
@@ -8190,72 +7890,20 @@
 			}
 		},
 		"node_modules/npm/node_modules/sigstore": {
-			"version": "3.1.0",
+			"version": "4.1.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@sigstore/bundle": "^3.1.0",
-				"@sigstore/core": "^2.0.0",
-				"@sigstore/protobuf-specs": "^0.4.0",
-				"@sigstore/sign": "^3.1.0",
-				"@sigstore/tuf": "^3.1.0",
-				"@sigstore/verify": "^2.1.0"
+				"@sigstore/bundle": "^4.0.0",
+				"@sigstore/core": "^3.2.1",
+				"@sigstore/protobuf-specs": "^0.5.0",
+				"@sigstore/sign": "^4.1.1",
+				"@sigstore/tuf": "^4.0.2",
+				"@sigstore/verify": "^3.1.1"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/npm/node_modules/sigstore/node_modules/@sigstore/bundle": {
-			"version": "3.1.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@sigstore/protobuf-specs": "^0.4.0"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/npm/node_modules/sigstore/node_modules/@sigstore/core": {
-			"version": "2.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/npm/node_modules/sigstore/node_modules/@sigstore/sign": {
-			"version": "3.1.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@sigstore/bundle": "^3.1.0",
-				"@sigstore/core": "^2.0.0",
-				"@sigstore/protobuf-specs": "^0.4.0",
-				"make-fetch-happen": "^14.0.2",
-				"proc-log": "^5.0.0",
-				"promise-retry": "^2.0.1"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/npm/node_modules/sigstore/node_modules/@sigstore/verify": {
-			"version": "2.1.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@sigstore/bundle": "^3.1.0",
-				"@sigstore/core": "^2.0.0",
-				"@sigstore/protobuf-specs": "^0.4.1"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/smart-buffer": {
@@ -8269,12 +7917,12 @@
 			}
 		},
 		"node_modules/npm/node_modules/socks": {
-			"version": "2.8.5",
+			"version": "2.8.9",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
-				"ip-address": "^9.0.5",
+				"ip-address": "^10.1.1",
 				"smart-buffer": "^4.2.0"
 			},
 			"engines": {
@@ -8296,26 +7944,6 @@
 				"node": ">= 14"
 			}
 		},
-		"node_modules/npm/node_modules/spdx-correct": {
-			"version": "3.2.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"spdx-expression-parse": "^3.0.0",
-				"spdx-license-ids": "^3.0.0"
-			}
-		},
-		"node_modules/npm/node_modules/spdx-correct/node_modules/spdx-expression-parse": {
-			"version": "3.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"spdx-exceptions": "^2.1.0",
-				"spdx-license-ids": "^3.0.0"
-			}
-		},
 		"node_modules/npm/node_modules/spdx-exceptions": {
 			"version": "2.5.0",
 			"dev": true,
@@ -8333,19 +7961,13 @@
 			}
 		},
 		"node_modules/npm/node_modules/spdx-license-ids": {
-			"version": "3.0.21",
+			"version": "3.0.23",
 			"dev": true,
 			"inBundle": true,
 			"license": "CC0-1.0"
 		},
-		"node_modules/npm/node_modules/sprintf-js": {
-			"version": "1.1.3",
-			"dev": true,
-			"inBundle": true,
-			"license": "BSD-3-Clause"
-		},
 		"node_modules/npm/node_modules/ssri": {
-			"version": "12.0.0",
+			"version": "13.0.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -8353,148 +7975,35 @@
 				"minipass": "^7.0.3"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/npm/node_modules/string-width": {
-			"version": "4.2.3",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/npm/node_modules/string-width-cjs": {
-			"name": "string-width",
-			"version": "4.2.3",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/npm/node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/npm/node_modules/strip-ansi-cjs": {
-			"name": "strip-ansi",
-			"version": "6.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/supports-color": {
-			"version": "9.4.0",
+			"version": "10.2.2",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/chalk/supports-color?sponsor=1"
 			}
 		},
 		"node_modules/npm/node_modules/tar": {
-			"version": "6.2.1",
+			"version": "7.5.15",
 			"dev": true,
 			"inBundle": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"chownr": "^2.0.0",
-				"fs-minipass": "^2.0.0",
-				"minipass": "^5.0.0",
-				"minizlib": "^2.1.1",
-				"mkdirp": "^1.0.3",
-				"yallist": "^4.0.0"
+				"@isaacs/fs-minipass": "^4.0.0",
+				"chownr": "^3.0.0",
+				"minipass": "^7.1.2",
+				"minizlib": "^3.1.0",
+				"yallist": "^5.0.0"
 			},
 			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/npm/node_modules/tar/node_modules/fs-minipass": {
-			"version": "2.1.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"minipass": "^3.0.0"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/npm/node_modules/tar/node_modules/fs-minipass/node_modules/minipass": {
-			"version": "3.3.6",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/npm/node_modules/tar/node_modules/minipass": {
-			"version": "5.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/npm/node_modules/tar/node_modules/minizlib": {
-			"version": "2.1.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"minipass": "^3.0.0",
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/npm/node_modules/tar/node_modules/minizlib/node_modules/minipass": {
-			"version": "3.3.6",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
+				"node": ">=18"
 			}
 		},
 		"node_modules/npm/node_modules/text-table": {
@@ -8504,19 +8013,19 @@
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/tiny-relative-date": {
-			"version": "1.3.0",
+			"version": "2.0.2",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/tinyglobby": {
-			"version": "0.2.14",
+			"version": "0.2.16",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
-				"fdir": "^6.4.4",
-				"picomatch": "^4.0.2"
+				"fdir": "^6.5.0",
+				"picomatch": "^4.0.4"
 			},
 			"engines": {
 				"node": ">=12.0.0"
@@ -8526,10 +8035,13 @@
 			}
 		},
 		"node_modules/npm/node_modules/tinyglobby/node_modules/fdir": {
-			"version": "6.4.6",
+			"version": "6.5.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			},
 			"peerDependencies": {
 				"picomatch": "^3 || ^4"
 			},
@@ -8540,7 +8052,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/tinyglobby/node_modules/picomatch": {
-			"version": "4.0.2",
+			"version": "4.0.4",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
@@ -8561,54 +8073,26 @@
 			}
 		},
 		"node_modules/npm/node_modules/tuf-js": {
-			"version": "3.0.1",
+			"version": "4.1.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
-				"@tufjs/models": "3.0.1",
-				"debug": "^4.3.6",
-				"make-fetch-happen": "^14.0.1"
+				"@tufjs/models": "4.1.0",
+				"debug": "^4.4.3",
+				"make-fetch-happen": "^15.0.1"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
-		"node_modules/npm/node_modules/tuf-js/node_modules/@tufjs/models": {
-			"version": "3.0.1",
+		"node_modules/npm/node_modules/undici": {
+			"version": "6.26.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"dependencies": {
-				"@tufjs/canonical-json": "2.0.0",
-				"minimatch": "^9.0.5"
-			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/npm/node_modules/unique-filename": {
-			"version": "4.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"unique-slug": "^5.0.0"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/npm/node_modules/unique-slug": {
-			"version": "5.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"imurmurhash": "^0.1.4"
-			},
-			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": ">=18.17"
 			}
 		},
 		"node_modules/npm/node_modules/util-deprecate": {
@@ -8617,183 +8101,59 @@
 			"inBundle": true,
 			"license": "MIT"
 		},
-		"node_modules/npm/node_modules/validate-npm-package-license": {
-			"version": "3.0.4",
-			"dev": true,
-			"inBundle": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"spdx-correct": "^3.0.0",
-				"spdx-expression-parse": "^3.0.0"
-			}
-		},
-		"node_modules/npm/node_modules/validate-npm-package-license/node_modules/spdx-expression-parse": {
-			"version": "3.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"spdx-exceptions": "^2.1.0",
-				"spdx-license-ids": "^3.0.0"
-			}
-		},
 		"node_modules/npm/node_modules/validate-npm-package-name": {
-			"version": "6.0.1",
+			"version": "7.0.2",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/walk-up-path": {
-			"version": "3.0.1",
+			"version": "4.0.0",
 			"dev": true,
 			"inBundle": true,
-			"license": "ISC"
+			"license": "ISC",
+			"engines": {
+				"node": "20 || >=22"
+			}
 		},
 		"node_modules/npm/node_modules/which": {
-			"version": "5.0.0",
+			"version": "6.0.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"isexe": "^3.1.1"
+				"isexe": "^4.0.0"
 			},
 			"bin": {
 				"node-which": "bin/which.js"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
-			}
-		},
-		"node_modules/npm/node_modules/which/node_modules/isexe": {
-			"version": "3.1.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=16"
-			}
-		},
-		"node_modules/npm/node_modules/wrap-ansi": {
-			"version": "8.1.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^6.1.0",
-				"string-width": "^5.0.1",
-				"strip-ansi": "^7.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-			}
-		},
-		"node_modules/npm/node_modules/wrap-ansi-cjs": {
-			"name": "wrap-ansi",
-			"version": "7.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^4.0.0",
-				"string-width": "^4.1.0",
-				"strip-ansi": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-			}
-		},
-		"node_modules/npm/node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
-			"version": "4.3.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"color-convert": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-regex": {
-			"version": "6.1.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
-			}
-		},
-		"node_modules/npm/node_modules/wrap-ansi/node_modules/emoji-regex": {
-			"version": "9.2.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT"
-		},
-		"node_modules/npm/node_modules/wrap-ansi/node_modules/string-width": {
-			"version": "5.1.2",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"eastasianwidth": "^0.2.0",
-				"emoji-regex": "^9.2.2",
-				"strip-ansi": "^7.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/npm/node_modules/wrap-ansi/node_modules/strip-ansi": {
-			"version": "7.1.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/write-file-atomic": {
-			"version": "6.0.0",
+			"version": "7.0.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"imurmurhash": "^0.1.4",
 				"signal-exit": "^4.0.1"
 			},
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/yallist": {
-			"version": "4.0.0",
+			"version": "5.0.0",
 			"dev": true,
 			"inBundle": true,
-			"license": "ISC"
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=18"
+			}
 		},
 		"node_modules/object-assign": {
 			"version": "4.1.1",
@@ -8885,16 +8245,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/p-is-promise": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-3.0.0.tgz",
-			"integrity": "sha512-Wo8VsW4IRQSKVXsJCn7TomUaVtyfjVDn3nUP7kE967BQk0CwFpdbZs0X0uk5sW9mkBa9eNM7hCMaG93WUAwxYQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/p-limit": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -8928,9 +8278,9 @@
 			}
 		},
 		"node_modules/p-map": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.3.tgz",
-			"integrity": "sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA==",
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
+			"integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -9195,9 +8545,9 @@
 			}
 		},
 		"node_modules/pretty-ms": {
-			"version": "9.2.0",
-			"resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.2.0.tgz",
-			"integrity": "sha512-4yf0QO/sllf/1zbZWYnvWw3NxCQwLXKzIj0G849LSufP15BXKM0rbD2Z3wVnkMfjdn/CB0Dpp444gYAACdsplg==",
+			"version": "9.3.0",
+			"resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+			"integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -9223,6 +8573,24 @@
 			"integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/proxy-agent-negotiate": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/proxy-agent-negotiate/-/proxy-agent-negotiate-1.1.0.tgz",
+			"integrity": "sha512-N8IBcM3UgCVzz2L2Lqv8DVntDnnC8/hiV4nEDUPkqq72TPUgYWjQc+bdZlBPZK9LzPAvOY//gAt0S0DApoOXWQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 20"
+			},
+			"peerDependencies": {
+				"kerberos": "^2.0.0"
+			},
+			"peerDependenciesMeta": {
+				"kerberos": {
+					"optional": true
+				}
+			}
 		},
 		"node_modules/punycode": {
 			"version": "2.3.1",
@@ -9281,51 +8649,54 @@
 			}
 		},
 		"node_modules/read-package-up": {
-			"version": "11.0.0",
-			"resolved": "https://registry.npmjs.org/read-package-up/-/read-package-up-11.0.0.tgz",
-			"integrity": "sha512-MbgfoNPANMdb4oRBNg5eqLbB2t2r+o5Ua1pNt8BqGp4I0FJZhuVSOj3PaBPni4azWuSzEdNn2evevzVmEk1ohQ==",
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/read-package-up/-/read-package-up-12.0.0.tgz",
+			"integrity": "sha512-Q5hMVBYur/eQNWDdbF4/Wqqr9Bjvtrw2kjGxxBbKLbx8bVCL8gcArjTy8zDUuLGQicftpMuU0riQNcAsbtOVsw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"find-up-simple": "^1.0.0",
-				"read-pkg": "^9.0.0",
-				"type-fest": "^4.6.0"
+				"find-up-simple": "^1.0.1",
+				"read-pkg": "^10.0.0",
+				"type-fest": "^5.2.0"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/read-package-up/node_modules/type-fest": {
-			"version": "4.41.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-			"integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.7.0.tgz",
+			"integrity": "sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==",
 			"dev": true,
 			"license": "(MIT OR CC0-1.0)",
+			"dependencies": {
+				"tagged-tag": "^1.0.0"
+			},
 			"engines": {
-				"node": ">=16"
+				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/read-pkg": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-9.0.1.tgz",
-			"integrity": "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==",
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-10.1.0.tgz",
+			"integrity": "sha512-I8g2lArQiP78ll51UeMZojewtYgIRCKCWqZEgOO8c/uefTI+XDXvCSXu3+YNUaTNvZzobrL5+SqHjBrByRRTdg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@types/normalize-package-data": "^2.4.3",
-				"normalize-package-data": "^6.0.0",
-				"parse-json": "^8.0.0",
-				"type-fest": "^4.6.0",
-				"unicorn-magic": "^0.1.0"
+				"@types/normalize-package-data": "^2.4.4",
+				"normalize-package-data": "^8.0.0",
+				"parse-json": "^8.3.0",
+				"type-fest": "^5.4.4",
+				"unicorn-magic": "^0.4.0"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -9349,7 +8720,7 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/read-pkg/node_modules/type-fest": {
+		"node_modules/read-pkg/node_modules/parse-json/node_modules/type-fest": {
 			"version": "4.41.0",
 			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
 			"integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
@@ -9362,14 +8733,30 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/read-pkg/node_modules/type-fest": {
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.7.0.tgz",
+			"integrity": "sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==",
+			"dev": true,
+			"license": "(MIT OR CC0-1.0)",
+			"dependencies": {
+				"tagged-tag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/read-pkg/node_modules/unicorn-magic": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
-			"integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.4.0.tgz",
+			"integrity": "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=18"
+				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -9409,13 +8796,13 @@
 			}
 		},
 		"node_modules/registry-auth-token": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-5.1.0.tgz",
-			"integrity": "sha512-GdekYuwLXLxMuFTwAPg5UKGLW/UXzQrZvH/Zj791BQif5T05T0RsaLfHc9q3ZOKi7n+BoprPD9mJ0O0k4xzUlw==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-5.1.1.tgz",
+			"integrity": "sha512-P7B4+jq8DeD2nMsAcdfaqHbssgHtZ7Z5+++a5ask90fvmJ8p5je4mOa+wzu+DB4vQ5tdJV/xywY+UnVFeQLV5Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@pnpm/npm-conf": "^2.1.0"
+				"@pnpm/npm-conf": "^3.0.2"
 			},
 			"engines": {
 				"node": ">=14"
@@ -9506,17 +8893,17 @@
 			"license": "MIT"
 		},
 		"node_modules/semantic-release": {
-			"version": "24.2.7",
-			"resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-24.2.7.tgz",
-			"integrity": "sha512-g7RssbTAbir1k/S7uSwSVZFfFXwpomUB9Oas0+xi9KStSCmeDXcA7rNhiskjLqvUe/Evhx8fVCT16OSa34eM5g==",
+			"version": "25.0.3",
+			"resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-25.0.3.tgz",
+			"integrity": "sha512-WRgl5GcypwramYX4HV+eQGzUbD7UUbljVmS+5G1uMwX/wLgYuJAxGeerXJDMO2xshng4+FXqCgyB5QfClV6WjA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@semantic-release/commit-analyzer": "^13.0.0-beta.1",
+				"@semantic-release/commit-analyzer": "^13.0.1",
 				"@semantic-release/error": "^4.0.0",
-				"@semantic-release/github": "^11.0.0",
-				"@semantic-release/npm": "^12.0.2",
-				"@semantic-release/release-notes-generator": "^14.0.0-beta.1",
+				"@semantic-release/github": "^12.0.0",
+				"@semantic-release/npm": "^13.1.1",
+				"@semantic-release/release-notes-generator": "^14.1.0",
 				"aggregate-error": "^5.0.0",
 				"cosmiconfig": "^9.0.0",
 				"debug": "^4.0.0",
@@ -9526,8 +8913,8 @@
 				"find-versions": "^6.0.0",
 				"get-stream": "^6.0.0",
 				"git-log-parser": "^1.2.0",
-				"hook-std": "^3.0.0",
-				"hosted-git-info": "^8.0.0",
+				"hook-std": "^4.0.0",
+				"hosted-git-info": "^9.0.0",
 				"import-from-esm": "^2.0.0",
 				"lodash-es": "^4.17.21",
 				"marked": "^15.0.0",
@@ -9535,19 +8922,66 @@
 				"micromatch": "^4.0.2",
 				"p-each-series": "^3.0.0",
 				"p-reduce": "^3.0.0",
-				"read-package-up": "^11.0.0",
+				"read-package-up": "^12.0.0",
 				"resolve-from": "^5.0.0",
 				"semver": "^7.3.2",
-				"semver-diff": "^4.0.0",
 				"signale": "^1.2.1",
-				"yargs": "^17.5.1"
+				"yargs": "^18.0.0"
 			},
 			"bin": {
 				"semantic-release": "bin/semantic-release.js"
 			},
 			"engines": {
-				"node": ">=20.8.1"
+				"node": "^22.14.0 || >= 24.10.0"
 			}
+		},
+		"node_modules/semantic-release/node_modules/ansi-regex": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/semantic-release/node_modules/ansi-styles": {
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+			"integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/semantic-release/node_modules/cliui": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+			"integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^7.2.0",
+				"strip-ansi": "^7.1.0",
+				"wrap-ansi": "^9.0.0"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/semantic-release/node_modules/emoji-regex": {
+			"version": "10.6.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+			"integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/semantic-release/node_modules/resolve-from": {
 			"version": "5.0.0",
@@ -9557,6 +8991,86 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/semantic-release/node_modules/string-width": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+			"integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^10.3.0",
+				"get-east-asian-width": "^1.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/semantic-release/node_modules/strip-ansi": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.2.2"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"node_modules/semantic-release/node_modules/wrap-ansi": {
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+			"integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^6.2.1",
+				"string-width": "^7.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/semantic-release/node_modules/yargs": {
+			"version": "18.0.0",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+			"integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cliui": "^9.0.1",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"string-width": "^7.2.0",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^22.0.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=23"
+			}
+		},
+		"node_modules/semantic-release/node_modules/yargs-parser": {
+			"version": "22.0.0",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+			"integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=23"
 			}
 		},
 		"node_modules/semver": {
@@ -9569,22 +9083,6 @@
 			},
 			"engines": {
 				"node": ">=10"
-			}
-		},
-		"node_modules/semver-diff": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-4.0.0.tgz",
-			"integrity": "sha512-0Ju4+6A8iOnpL/Thra7dZsSlOHYAHIeMxfhWQRI1/VLcT3WDBZKKtQt/QkBOsiIN9ZpuvHE6cGZ0x4glCMmfiA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"semver": "^7.3.5"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/semver-regex": {
@@ -9813,9 +9311,9 @@
 			}
 		},
 		"node_modules/spdx-license-ids": {
-			"version": "3.0.21",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.21.tgz",
-			"integrity": "sha512-Bvg/8F5XephndSK3JffaRqdT+gyhfqIPwDHpX80tJrF8QQRYMo8sNMeaZ2Dp5+jhwKnUmIOyFFQfHRkjJm5nXg==",
+			"version": "3.0.23",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+			"integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
 			"dev": true,
 			"license": "CC0-1.0"
 		},
@@ -9972,6 +9470,19 @@
 				"url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
 			}
 		},
+		"node_modules/tagged-tag": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+			"integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/tar": {
 			"version": "7.4.3",
 			"resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
@@ -10015,9 +9526,9 @@
 			"license": "ISC"
 		},
 		"node_modules/tempy": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/tempy/-/tempy-3.1.0.tgz",
-			"integrity": "sha512-7jDLIdD2Zp0bDe5r3D2qtkd1QOCacylBuL7oa4udvN6v2pqr4+LcCr67C8DR1zkpaZ8XosF5m1yQSabKAW6f2g==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/tempy/-/tempy-3.2.0.tgz",
+			"integrity": "sha512-d79HhZya5Djd7am0q+W4RTsSU+D/aJzM+4Y4AGJGuGlgM2L6sx5ZvOYTmZjqPhrDrV6xJTtRSm1JCLj6V6LHLQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -10116,6 +9627,54 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/tinyglobby": {
+			"version": "0.2.17",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+			"integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fdir": "^6.5.0",
+				"picomatch": "^4.0.4"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/SuperchupuDev"
+			}
+		},
+		"node_modules/tinyglobby/node_modules/fdir": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"peerDependencies": {
+				"picomatch": "^3 || ^4"
+			},
+			"peerDependenciesMeta": {
+				"picomatch": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/tinyglobby/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
 		"node_modules/tmp": {
 			"version": "0.0.33",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -10193,6 +9752,16 @@
 				"fsevents": "~2.3.3"
 			}
 		},
+		"node_modules/tunnel": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+			"integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+			}
+		},
 		"node_modules/type-check": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -10244,6 +9813,16 @@
 			},
 			"engines": {
 				"node": ">=0.8.0"
+			}
+		},
+		"node_modules/undici": {
+			"version": "7.27.2",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.27.2.tgz",
+			"integrity": "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.18.1"
 			}
 		},
 		"node_modules/undici-types": {
@@ -10532,9 +10111,9 @@
 			}
 		},
 		"node_modules/yoctocolors": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.1.tgz",
-			"integrity": "sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+			"integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 		"eslint": "^9.15.0",
 		"prettier": "^3.3.3",
 		"recast": "^0.23.11",
-		"semantic-release": "^24.2.7",
+		"semantic-release": "^25.0.3",
 		"tsx": "^4.21.0",
 		"typescript": "^5.8.3"
 	},


### PR DESCRIPTION
Follow-up to #33. The publish still failed with `ENONPMTOKEN` because `@semantic-release/npm@12.0.2` (bundled by semantic-release 24) mandates a token. Tokenless OIDC publishing was added in `@semantic-release/npm@13.1.0`; this upgrades to semantic-release v25 (bundles 13.1.5).