### PR TITLE
fix: add repository field for npm provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
 	"type": "module",
 	"main": "dist/src/index.js",
 	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/mvhenten/typespec-electrodb-emitter.git"
+	},
 	"release": {
 		"preset": "conventionalcommits"
 	},


### PR DESCRIPTION
Final fix in the publish chain (#33, #35). OIDC auth + provenance signing now work, but the publish 422s because npm provenance requires `package.json` `repository.url` to match the GitHub repo, and the field was missing.