### PR TITLE
fix: skip @index re-application on visibility-mutated model clones

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [22.x, 24.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -840,12 +840,12 @@
 			}
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-			"integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+			"integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.27.1",
+				"@babel/helper-validator-identifier": "^7.29.7",
 				"js-tokens": "^4.0.0",
 				"picocolors": "^1.1.1"
 			},
@@ -879,9 +879,9 @@
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-			"integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+			"integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
@@ -1820,20 +1820,28 @@
 				"url": "https://github.com/sponsors/nzakas"
 			}
 		},
+		"node_modules/@inquirer/ansi": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.7.tgz",
+			"integrity": "sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+			}
+		},
 		"node_modules/@inquirer/checkbox": {
-			"version": "4.1.8",
-			"resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.1.8.tgz",
-			"integrity": "sha512-d/QAsnwuHX2OPolxvYcgSj7A9DO9H6gVOy2DvBTx+P2LH2iRTo/RSGV3iwCzW024nP9hw98KIuDmdyhZQj1UQg==",
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.2.1.tgz",
+			"integrity": "sha512-b6xmA/VlTe0ZgDQHDui+Nav470u7u49nRd8/iuhOcQPO9Ch7lGuogydhi2VOmNlZ+zXcM8IcPuNSwQcdJaF/kw==",
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^10.1.13",
-				"@inquirer/figures": "^1.0.12",
-				"@inquirer/type": "^3.0.7",
-				"ansi-escapes": "^4.3.2",
-				"yoctocolors-cjs": "^2.1.2"
+				"@inquirer/ansi": "^2.0.7",
+				"@inquirer/core": "^11.2.1",
+				"@inquirer/figures": "^2.0.7",
+				"@inquirer/type": "^4.0.7"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
 			},
 			"peerDependencies": {
 				"@types/node": ">=18"
@@ -1845,16 +1853,16 @@
 			}
 		},
 		"node_modules/@inquirer/confirm": {
-			"version": "5.1.12",
-			"resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.12.tgz",
-			"integrity": "sha512-dpq+ielV9/bqgXRUbNH//KsY6WEw9DrGPmipkpmgC1Y46cwuBTNx7PXFWTjc3MQ+urcc0QxoVHcMI0FW4Ok0hg==",
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.1.1.tgz",
+			"integrity": "sha512-eb8DBZcz/2qHWQda4rk2JiQk5h9QV/cVHi1yjt0f69WFZMRFn0sJTye3EAP8icut8UDMjQPsaH5KbcOogefrFQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^10.1.13",
-				"@inquirer/type": "^3.0.7"
+				"@inquirer/core": "^11.2.1",
+				"@inquirer/type": "^4.0.7"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
 			},
 			"peerDependencies": {
 				"@types/node": ">=18"
@@ -1866,22 +1874,21 @@
 			}
 		},
 		"node_modules/@inquirer/core": {
-			"version": "10.1.13",
-			"resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.13.tgz",
-			"integrity": "sha512-1viSxebkYN2nJULlzCxES6G9/stgHSepZ9LqqfdIGPHj5OHhiBUXVS0a6R0bEC2A+VL4D9w6QB66ebCr6HGllA==",
+			"version": "11.2.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.2.1.tgz",
+			"integrity": "sha512-Qd6GJT1yVyrZZCfN8W2qKF5ApmqryXRhRKCuip8h01x2w/esJQ2XIYc6f9abMIHgKQdBfFTSOdbHRLAhuM09UA==",
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/figures": "^1.0.12",
-				"@inquirer/type": "^3.0.7",
-				"ansi-escapes": "^4.3.2",
+				"@inquirer/ansi": "^2.0.7",
+				"@inquirer/figures": "^2.0.7",
+				"@inquirer/type": "^4.0.7",
 				"cli-width": "^4.1.0",
-				"mute-stream": "^2.0.0",
-				"signal-exit": "^4.1.0",
-				"wrap-ansi": "^6.2.0",
-				"yoctocolors-cjs": "^2.1.2"
+				"fast-wrap-ansi": "^0.2.0",
+				"mute-stream": "^3.0.0",
+				"signal-exit": "^4.1.0"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
 			},
 			"peerDependencies": {
 				"@types/node": ">=18"
@@ -1893,17 +1900,17 @@
 			}
 		},
 		"node_modules/@inquirer/editor": {
-			"version": "4.2.13",
-			"resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.13.tgz",
-			"integrity": "sha512-WbicD9SUQt/K8O5Vyk9iC2ojq5RHoCLK6itpp2fHsWe44VxxcA9z3GTWlvjSTGmMQpZr+lbVmrxdHcumJoLbMA==",
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.2.2.tgz",
+			"integrity": "sha512-ZRVd/oD+sYsUd5zVm0NflqEzlqfYCyHNsqkHl2oWXEUHs12tCbcSFi+wVFEvD8+LGRaMUsVrE7qeo6lSG/S1Vg==",
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^10.1.13",
-				"@inquirer/type": "^3.0.7",
-				"external-editor": "^3.1.0"
+				"@inquirer/core": "^11.2.1",
+				"@inquirer/external-editor": "^3.0.3",
+				"@inquirer/type": "^4.0.7"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
 			},
 			"peerDependencies": {
 				"@types/node": ">=18"
@@ -1915,17 +1922,37 @@
 			}
 		},
 		"node_modules/@inquirer/expand": {
-			"version": "4.0.15",
-			"resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.15.tgz",
-			"integrity": "sha512-4Y+pbr/U9Qcvf+N/goHzPEXiHH8680lM3Dr3Y9h9FFw4gHS+zVpbj8LfbKWIb/jayIB4aSO4pWiBTrBYWkvi5A==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.1.1.tgz",
+			"integrity": "sha512-YmQpenjbFSHAK3sOd44puHh3V1KXXr+JiNpUztoSQ4drLh2rTVzTap/YtlAVu/5xavifIlBfNEzJ/neZJ1a/1g==",
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^10.1.13",
-				"@inquirer/type": "^3.0.7",
-				"yoctocolors-cjs": "^2.1.2"
+				"@inquirer/core": "^11.2.1",
+				"@inquirer/type": "^4.0.7"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/external-editor": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.3.tgz",
+			"integrity": "sha512-6thf5I8q7lZwzGLAxPaaGEREEkZ3nyePPDQ1oyobblxmEE8mqTLguScP7pDjUTAibiyb4hfXl+qjUEJ+di/aNA==",
+			"license": "MIT",
+			"dependencies": {
+				"chardet": "^2.1.1",
+				"iconv-lite": "^0.7.2"
+			},
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
 			},
 			"peerDependencies": {
 				"@types/node": ">=18"
@@ -1937,25 +1964,25 @@
 			}
 		},
 		"node_modules/@inquirer/figures": {
-			"version": "1.0.12",
-			"resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.12.tgz",
-			"integrity": "sha512-MJttijd8rMFcKJC8NYmprWr6hD3r9Gd9qUC0XwPNwoEPWSMVJwA2MlXxF+nhZZNMY+HXsWa+o7KY2emWYIn0jQ==",
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.7.tgz",
+			"integrity": "sha512-aJ8TBPOGB6f/2qziPfElISTCEd5XOYTFckA2SGjhNmiKzfK/u4ot3v0DUzGVdUnKjN10EqnnEPck36BkyfLnJw==",
 			"license": "MIT",
 			"engines": {
-				"node": ">=18"
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
 			}
 		},
 		"node_modules/@inquirer/input": {
-			"version": "4.1.12",
-			"resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.1.12.tgz",
-			"integrity": "sha512-xJ6PFZpDjC+tC1P8ImGprgcsrzQRsUh9aH3IZixm1lAZFK49UGHxM3ltFfuInN2kPYNfyoPRh+tU4ftsjPLKqQ==",
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.1.2.tgz",
+			"integrity": "sha512-9K/DDBSQpOyZSkt6sOVP9Vo0TR7atX2kuILsUu0x3wVcVbe97lJwIJKMLdMw25tDYuXl/qp6erT0Xs1rfmcfZg==",
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^10.1.13",
-				"@inquirer/type": "^3.0.7"
+				"@inquirer/core": "^11.2.1",
+				"@inquirer/type": "^4.0.7"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
 			},
 			"peerDependencies": {
 				"@types/node": ">=18"
@@ -1967,16 +1994,16 @@
 			}
 		},
 		"node_modules/@inquirer/number": {
-			"version": "3.0.15",
-			"resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.15.tgz",
-			"integrity": "sha512-xWg+iYfqdhRiM55MvqiTCleHzszpoigUpN5+t1OMcRkJrUrw7va3AzXaxvS+Ak7Gny0j2mFSTv2JJj8sMtbV2g==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.1.1.tgz",
+			"integrity": "sha512-XF4IXAbPnGPgw0wsbC/i2tPcyfdZgDpUlhsqU0SfT4IRIGWha6Xm9VRgN5yYxJq+jnyXlfXI/nQ3ulfk0iEICA==",
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^10.1.13",
-				"@inquirer/type": "^3.0.7"
+				"@inquirer/core": "^11.2.1",
+				"@inquirer/type": "^4.0.7"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
 			},
 			"peerDependencies": {
 				"@types/node": ">=18"
@@ -1988,17 +2015,17 @@
 			}
 		},
 		"node_modules/@inquirer/password": {
-			"version": "4.0.15",
-			"resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.15.tgz",
-			"integrity": "sha512-75CT2p43DGEnfGTaqFpbDC2p2EEMrq0S+IRrf9iJvYreMy5mAWj087+mdKyLHapUEPLjN10mNvABpGbk8Wdraw==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.1.1.tgz",
+			"integrity": "sha512-3XBfF7DAsp5qeDsvN5Rd1HmbNokVvEQoUM0QLrRcybC9nX96w3Pbmu7qUsb3IT3J3jBvs2+mTXaKHOUsgHMLzg==",
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^10.1.13",
-				"@inquirer/type": "^3.0.7",
-				"ansi-escapes": "^4.3.2"
+				"@inquirer/ansi": "^2.0.7",
+				"@inquirer/core": "^11.2.1",
+				"@inquirer/type": "^4.0.7"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
 			},
 			"peerDependencies": {
 				"@types/node": ">=18"
@@ -2010,24 +2037,24 @@
 			}
 		},
 		"node_modules/@inquirer/prompts": {
-			"version": "7.5.3",
-			"resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.5.3.tgz",
-			"integrity": "sha512-8YL0WiV7J86hVAxrh3fE5mDCzcTDe1670unmJRz6ArDgN+DBK1a0+rbnNWp4DUB5rPMwqD5ZP6YHl9KK1mbZRg==",
+			"version": "8.5.2",
+			"resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.5.2.tgz",
+			"integrity": "sha512-IYR/3C/paEVVQYQvdDlFZVjRCJVYHHON0XXMH91KO9GSxs0TdKYWlUdvfQl2EfAHDxUaN3IBffkE/BDTh5nJ6g==",
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/checkbox": "^4.1.8",
-				"@inquirer/confirm": "^5.1.12",
-				"@inquirer/editor": "^4.2.13",
-				"@inquirer/expand": "^4.0.15",
-				"@inquirer/input": "^4.1.12",
-				"@inquirer/number": "^3.0.15",
-				"@inquirer/password": "^4.0.15",
-				"@inquirer/rawlist": "^4.1.3",
-				"@inquirer/search": "^3.0.15",
-				"@inquirer/select": "^4.2.3"
+				"@inquirer/checkbox": "^5.2.1",
+				"@inquirer/confirm": "^6.1.1",
+				"@inquirer/editor": "^5.2.2",
+				"@inquirer/expand": "^5.1.1",
+				"@inquirer/input": "^5.1.2",
+				"@inquirer/number": "^4.1.1",
+				"@inquirer/password": "^5.1.1",
+				"@inquirer/rawlist": "^5.3.1",
+				"@inquirer/search": "^4.2.1",
+				"@inquirer/select": "^5.2.1"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
 			},
 			"peerDependencies": {
 				"@types/node": ">=18"
@@ -2039,17 +2066,16 @@
 			}
 		},
 		"node_modules/@inquirer/rawlist": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.3.tgz",
-			"integrity": "sha512-7XrV//6kwYumNDSsvJIPeAqa8+p7GJh7H5kRuxirct2cgOcSWwwNGoXDRgpNFbY/MG2vQ4ccIWCi8+IXXyFMZA==",
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.3.1.tgz",
+			"integrity": "sha512-QqdTqQddL3qPX/PPrjobpsO25NZ4dWXgTLenrR445L2ptLEYE6Z+PD5c5CNDJNx4ugRgELAIpSIJxZaO2jJ2Og==",
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^10.1.13",
-				"@inquirer/type": "^3.0.7",
-				"yoctocolors-cjs": "^2.1.2"
+				"@inquirer/core": "^11.2.1",
+				"@inquirer/type": "^4.0.7"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
 			},
 			"peerDependencies": {
 				"@types/node": ">=18"
@@ -2061,18 +2087,17 @@
 			}
 		},
 		"node_modules/@inquirer/search": {
-			"version": "3.0.15",
-			"resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.0.15.tgz",
-			"integrity": "sha512-YBMwPxYBrADqyvP4nNItpwkBnGGglAvCLVW8u4pRmmvOsHUtCAUIMbUrLX5B3tFL1/WsLGdQ2HNzkqswMs5Uaw==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.2.1.tgz",
+			"integrity": "sha512-xJj8QWKRSrfKoBIITLZK61dD3zwo0Rz11fgDImku30/Oe81zMdIdGgrLY2h6RkJ+KZ/GhNYIRMKnH/62qBTA5g==",
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^10.1.13",
-				"@inquirer/figures": "^1.0.12",
-				"@inquirer/type": "^3.0.7",
-				"yoctocolors-cjs": "^2.1.2"
+				"@inquirer/core": "^11.2.1",
+				"@inquirer/figures": "^2.0.7",
+				"@inquirer/type": "^4.0.7"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
 			},
 			"peerDependencies": {
 				"@types/node": ">=18"
@@ -2084,19 +2109,18 @@
 			}
 		},
 		"node_modules/@inquirer/select": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.2.3.tgz",
-			"integrity": "sha512-OAGhXU0Cvh0PhLz9xTF/kx6g6x+sP+PcyTiLvCrewI99P3BBeexD+VbuwkNDvqGkk3y2h5ZiWLeRP7BFlhkUDg==",
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.2.1.tgz",
+			"integrity": "sha512-FlDndEUww8m7BfukO2nJa25vhD+H5jxxCv4oGioKqzyWz3nPHhhw4LKdYRSlXuAx7DsdWia7iyaBPKKS95Evfw==",
 			"license": "MIT",
 			"dependencies": {
-				"@inquirer/core": "^10.1.13",
-				"@inquirer/figures": "^1.0.12",
-				"@inquirer/type": "^3.0.7",
-				"ansi-escapes": "^4.3.2",
-				"yoctocolors-cjs": "^2.1.2"
+				"@inquirer/ansi": "^2.0.7",
+				"@inquirer/core": "^11.2.1",
+				"@inquirer/figures": "^2.0.7",
+				"@inquirer/type": "^4.0.7"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
 			},
 			"peerDependencies": {
 				"@types/node": ">=18"
@@ -2108,12 +2132,12 @@
 			}
 		},
 		"node_modules/@inquirer/type": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.7.tgz",
-			"integrity": "sha512-PfunHQcjwnju84L+ycmcMKB/pTPIngjUJvfnRhKY6FKPuYXlM4aQCb/nIdTFR6BEhMjFvngzvng/vBAJMZpLSA==",
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.7.tgz",
+			"integrity": "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==",
 			"license": "MIT",
 			"engines": {
-				"node": ">=18"
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
 			},
 			"peerDependencies": {
 				"@types/node": ">=18"
@@ -2188,6 +2212,7 @@
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
 			"integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@nodelib/fs.stat": "2.0.5",
@@ -2201,6 +2226,7 @@
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
 			"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 8"
@@ -2210,6 +2236,7 @@
 			"version": "1.2.8",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
 			"integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@nodelib/fs.scandir": "2.1.5",
@@ -2674,18 +2701,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sindresorhus/is?sponsor=1"
-			}
-		},
-		"node_modules/@sindresorhus/merge-streams": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
-			"integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/@smithy/abort-controller": {
@@ -3607,35 +3622,34 @@
 			}
 		},
 		"node_modules/@typespec/compiler": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@typespec/compiler/-/compiler-1.1.0.tgz",
-			"integrity": "sha512-dtwosIqd2UUEEIVBR+oDiUtN4n1lP8/9GxQVno+wbkijQgKDj4Hg0Vaq6HG4BduF7RptDdtzkdGQCS9CgOIdRA==",
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/@typespec/compiler/-/compiler-1.13.0.tgz",
+			"integrity": "sha512-DonoHiyAMx0UjSmssqTrFtya+v97wny1aHcTLU5QF2wFzLATtcwUU9hbPC+eXhepuTunMOCHf8yk3pEsH6PZYA==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/code-frame": "~7.27.1",
-				"@inquirer/prompts": "^7.4.0",
-				"ajv": "~8.17.1",
-				"change-case": "~5.4.4",
-				"env-paths": "^3.0.0",
-				"globby": "~14.1.0",
+				"@babel/code-frame": "^7.29.0",
+				"@inquirer/prompts": "^8.4.1",
+				"ajv": "^8.18.0",
+				"change-case": "^5.4.4",
+				"env-paths": "^4.0.0",
 				"is-unicode-supported": "^2.1.0",
-				"mustache": "~4.2.0",
-				"picocolors": "~1.1.1",
-				"prettier": "~3.5.3",
-				"semver": "^7.7.1",
-				"tar": "^7.4.3",
-				"temporal-polyfill": "^0.3.0",
-				"vscode-languageserver": "~9.0.1",
-				"vscode-languageserver-textdocument": "~1.0.12",
-				"yaml": "~2.7.0",
-				"yargs": "~17.7.2"
+				"mustache": "^4.2.0",
+				"picocolors": "^1.1.1",
+				"prettier": "^3.8.1",
+				"semver": "^7.7.4",
+				"tar": "^7.5.13",
+				"temporal-polyfill": "^0.3.2",
+				"vscode-languageserver": "^9.0.1",
+				"vscode-languageserver-textdocument": "^1.0.12",
+				"yaml": "^2.8.3",
+				"yargs": "^18.0.0"
 			},
 			"bin": {
 				"tsp": "cmd/tsp.js",
 				"tsp-server": "cmd/tsp-server.js"
 			},
 			"engines": {
-				"node": ">=20.0.0"
+				"node": ">=22.0.0"
 			}
 		},
 		"node_modules/acorn": {
@@ -3689,9 +3703,9 @@
 			}
 		},
 		"node_modules/ajv": {
-			"version": "8.17.1",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+			"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
 			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
@@ -3704,25 +3718,11 @@
 				"url": "https://github.com/sponsors/epoberezkin"
 			}
 		},
-		"node_modules/ansi-escapes": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
-			"integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
-			"license": "MIT",
-			"dependencies": {
-				"type-fest": "^0.21.3"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/ansi-regex": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
 			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -3732,6 +3732,7 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
 			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"color-convert": "^2.0.1"
@@ -3827,6 +3828,7 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
 			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"fill-range": "^7.1.1"
@@ -3879,9 +3881,9 @@
 			}
 		},
 		"node_modules/chardet": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
+			"integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
 			"license": "MIT"
 		},
 		"node_modules/chownr": {
@@ -4029,40 +4031,74 @@
 			}
 		},
 		"node_modules/cliui": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+			"integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
 			"license": "ISC",
 			"dependencies": {
-				"string-width": "^4.2.0",
-				"strip-ansi": "^6.0.1",
-				"wrap-ansi": "^7.0.0"
+				"string-width": "^7.2.0",
+				"strip-ansi": "^7.1.0",
+				"wrap-ansi": "^9.0.0"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/cliui/node_modules/ansi-regex": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/cliui/node_modules/emoji-regex": {
+			"version": "10.6.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+			"integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+			"license": "MIT"
+		},
+		"node_modules/cliui/node_modules/string-width": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+			"integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^10.3.0",
+				"get-east-asian-width": "^1.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/cliui/node_modules/strip-ansi": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.2.2"
 			},
 			"engines": {
 				"node": ">=12"
-			}
-		},
-		"node_modules/cliui/node_modules/wrap-ansi": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^4.0.0",
-				"string-width": "^4.1.0",
-				"strip-ansi": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=10"
 			},
 			"funding": {
-				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
 			}
 		},
 		"node_modules/color-convert": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
 			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"color-name": "~1.1.4"
@@ -4075,6 +4111,7 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/compare-func": {
@@ -4389,6 +4426,7 @@
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/emojilib": {
@@ -4515,12 +4553,15 @@
 			}
 		},
 		"node_modules/env-paths": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
-			"integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-4.0.0.tgz",
+			"integrity": "sha512-pxP8eL2SwwaTRi/KHYwLYXinDs7gL3jxFcBYmEdYfZmZXbaVDvdppd0XBU8qVz03rDfKZMXg1omHCbsJjZrMsw==",
 			"license": "MIT",
+			"dependencies": {
+				"is-safe-filename": "^0.1.0"
+			},
 			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -4923,20 +4964,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/external-editor": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
-			"integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-			"license": "MIT",
-			"dependencies": {
-				"chardet": "^0.7.0",
-				"iconv-lite": "^0.4.24",
-				"tmp": "^0.0.33"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -4947,6 +4974,7 @@
 			"version": "3.3.3",
 			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
 			"integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@nodelib/fs.stat": "^2.0.2",
@@ -4963,6 +4991,7 @@
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
 			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"is-glob": "^4.0.1"
@@ -4985,10 +5014,25 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/fast-string-truncated-width": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+			"integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+			"license": "MIT"
+		},
+		"node_modules/fast-string-width": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+			"integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+			"license": "MIT",
+			"dependencies": {
+				"fast-string-truncated-width": "^3.0.2"
+			}
+		},
 		"node_modules/fast-uri": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
-			"integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+			"integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
 			"funding": [
 				{
 					"type": "github",
@@ -5000,6 +5044,15 @@
 				}
 			],
 			"license": "BSD-3-Clause"
+		},
+		"node_modules/fast-wrap-ansi": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+			"integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
+			"license": "MIT",
+			"dependencies": {
+				"fast-string-width": "^3.0.2"
+			}
 		},
 		"node_modules/fast-xml-parser": {
 			"version": "4.4.1",
@@ -5028,6 +5081,7 @@
 			"version": "1.19.1",
 			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
 			"integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"reusify": "^1.0.4"
@@ -5066,6 +5120,7 @@
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
 			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"to-regex-range": "^5.0.1"
@@ -5198,7 +5253,6 @@
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
 			"integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -5267,26 +5321,6 @@
 			"integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
 			"dev": true,
 			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/globby": {
-			"version": "14.1.0",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-14.1.0.tgz",
-			"integrity": "sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==",
-			"license": "MIT",
-			"dependencies": {
-				"@sindresorhus/merge-streams": "^2.1.0",
-				"fast-glob": "^3.3.3",
-				"ignore": "^7.0.3",
-				"path-type": "^6.0.0",
-				"slash": "^5.1.0",
-				"unicorn-magic": "^0.3.0"
-			},
 			"engines": {
 				"node": ">=18"
 			},
@@ -5417,21 +5451,26 @@
 			}
 		},
 		"node_modules/iconv-lite": {
-			"version": "0.4.24",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+			"integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
 			"license": "MIT",
 			"dependencies": {
-				"safer-buffer": ">= 2.1.2 < 3"
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
 			},
 			"engines": {
 				"node": ">=0.10.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/ignore": {
 			"version": "7.0.5",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
 			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 4"
@@ -5540,6 +5579,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
 			"integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -5549,6 +5589,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
 			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -5558,6 +5599,7 @@
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
 			"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"is-extglob": "^2.1.1"
@@ -5570,6 +5612,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.12.0"
@@ -5593,6 +5636,18 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/is-safe-filename": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/is-safe-filename/-/is-safe-filename-0.1.1.tgz",
+			"integrity": "sha512-4SrR7AdnY11LHfDKTZY1u6Ga3RuxZdl3YKWWShO5iyuG5h8QS4GD2tOb04peBJ5I7pXbR+CGBNEhTcwK+FzN3g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -5996,6 +6051,7 @@
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
 			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 8"
@@ -6005,6 +6061,7 @@
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
 			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"braces": "^3.0.3",
@@ -6070,39 +6127,24 @@
 			}
 		},
 		"node_modules/minipass": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-			"license": "ISC",
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
 			}
 		},
 		"node_modules/minizlib": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.2.tgz",
-			"integrity": "sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+			"integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
 			"license": "MIT",
 			"dependencies": {
 				"minipass": "^7.1.2"
 			},
 			"engines": {
 				"node": ">= 18"
-			}
-		},
-		"node_modules/mkdirp": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
-			"integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-			"license": "MIT",
-			"bin": {
-				"mkdirp": "dist/cjs/src/bin.js"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/mnemonist": {
@@ -6133,12 +6175,12 @@
 			}
 		},
 		"node_modules/mute-stream": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
-			"integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+			"integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
 			"license": "ISC",
 			"engines": {
-				"node": "^18.17.0 || >=20.5.0"
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/mz": {
@@ -8207,15 +8249,6 @@
 				"node": ">= 0.8.0"
 			}
 		},
-		"node_modules/os-tmpdir": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/p-each-series": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-3.0.0.tgz",
@@ -8402,18 +8435,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/path-type": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/path-type/-/path-type-6.0.0.tgz",
-			"integrity": "sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/picocolors": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -8424,6 +8445,7 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
 			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8.6"
@@ -8530,9 +8552,9 @@
 			}
 		},
 		"node_modules/prettier": {
-			"version": "3.5.3",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
-			"integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+			"version": "3.8.4",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
+			"integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
 			"license": "MIT",
 			"bin": {
 				"prettier": "bin/prettier.cjs"
@@ -8606,6 +8628,7 @@
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
 			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -8812,6 +8835,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
 			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -8850,6 +8874,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
 			"integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"iojs": ">=1.0.0",
@@ -8860,6 +8885,7 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
 			"integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -8935,54 +8961,6 @@
 				"node": "^22.14.0 || >= 24.10.0"
 			}
 		},
-		"node_modules/semantic-release/node_modules/ansi-regex": {
-			"version": "6.2.2",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
-			}
-		},
-		"node_modules/semantic-release/node_modules/ansi-styles": {
-			"version": "6.2.3",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-			"integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/semantic-release/node_modules/cliui": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
-			"integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"string-width": "^7.2.0",
-				"strip-ansi": "^7.1.0",
-				"wrap-ansi": "^9.0.0"
-			},
-			"engines": {
-				"node": ">=20"
-			}
-		},
-		"node_modules/semantic-release/node_modules/emoji-regex": {
-			"version": "10.6.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
-			"integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/semantic-release/node_modules/resolve-from": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -8993,90 +8971,10 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/semantic-release/node_modules/string-width": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-			"integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"emoji-regex": "^10.3.0",
-				"get-east-asian-width": "^1.0.0",
-				"strip-ansi": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/semantic-release/node_modules/strip-ansi": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^6.2.2"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
-			}
-		},
-		"node_modules/semantic-release/node_modules/wrap-ansi": {
-			"version": "9.0.2",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
-			"integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^6.2.1",
-				"string-width": "^7.0.0",
-				"strip-ansi": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-			}
-		},
-		"node_modules/semantic-release/node_modules/yargs": {
-			"version": "18.0.0",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
-			"integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"cliui": "^9.0.1",
-				"escalade": "^3.1.1",
-				"get-caller-file": "^2.0.5",
-				"string-width": "^7.2.0",
-				"y18n": "^5.0.5",
-				"yargs-parser": "^22.0.0"
-			},
-			"engines": {
-				"node": "^20.19.0 || ^22.12.0 || >=23"
-			}
-		},
-		"node_modules/semantic-release/node_modules/yargs-parser": {
-			"version": "22.0.0",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
-			"integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^20.19.0 || ^22.12.0 || >=23"
-			}
-		},
 		"node_modules/semver": {
-			"version": "7.7.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+			"integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
@@ -9252,18 +9150,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/slash": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
-			"integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=14.16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/source-map": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -9352,6 +9238,7 @@
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
 			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"emoji-regex": "^8.0.0",
@@ -9366,6 +9253,7 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
 			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
@@ -9484,16 +9372,15 @@
 			}
 		},
 		"node_modules/tar": {
-			"version": "7.4.3",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
-			"integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
-			"license": "ISC",
+			"version": "7.5.16",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
+			"integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
 				"@isaacs/fs-minipass": "^4.0.0",
 				"chownr": "^3.0.0",
 				"minipass": "^7.1.2",
-				"minizlib": "^3.0.1",
-				"mkdirp": "^3.0.1",
+				"minizlib": "^3.1.0",
 				"yallist": "^5.0.0"
 			},
 			"engines": {
@@ -9511,18 +9398,18 @@
 			}
 		},
 		"node_modules/temporal-polyfill": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-0.3.0.tgz",
-			"integrity": "sha512-qNsTkX9K8hi+FHDfHmf22e/OGuXmfBm9RqNismxBrnSmZVJKegQ+HYYXT+R7Ha8F/YSm2Y34vmzD4cxMu2u95g==",
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-0.3.2.tgz",
+			"integrity": "sha512-TzHthD/heRK947GNiSu3Y5gSPpeUDH34+LESnfsq8bqpFhsB79HFBX8+Z834IVX68P3EUyRPZK5bL/1fh437Eg==",
 			"license": "MIT",
 			"dependencies": {
-				"temporal-spec": "0.3.0"
+				"temporal-spec": "0.3.1"
 			}
 		},
 		"node_modules/temporal-spec": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-0.3.0.tgz",
-			"integrity": "sha512-n+noVpIqz4hYgFSMOSiINNOUOMFtV5cZQNCmmszA6GiVFVRt3G7AqVyhXjhCSmowvQn+NsGn+jMDMKJYHd3bSQ==",
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-0.3.1.tgz",
+			"integrity": "sha512-B4TUhezh9knfSIMwt7RVggApDRJZo73uZdj8AacL2mZ8RP5KtLianh2MXxL06GN9ESYiIsiuoLQhgVfwe55Yhw==",
 			"license": "ISC"
 		},
 		"node_modules/tempy": {
@@ -9675,22 +9562,11 @@
 				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
-		"node_modules/tmp": {
-			"version": "0.0.33",
-			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-			"license": "MIT",
-			"dependencies": {
-				"os-tmpdir": "~1.0.2"
-			},
-			"engines": {
-				"node": ">=0.6.0"
-			}
-		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
 			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"is-number": "^7.0.0"
@@ -9775,18 +9651,6 @@
 				"node": ">= 0.8.0"
 			}
 		},
-		"node_modules/type-fest": {
-			"version": "0.21.3",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-			"integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-			"license": "(MIT OR CC0-1.0)",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/typescript": {
 			"version": "5.8.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
@@ -9846,6 +9710,7 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
 			"integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -10017,17 +9882,82 @@
 			"license": "MIT"
 		},
 		"node_modules/wrap-ansi": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-			"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+			"integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
 			"license": "MIT",
 			"dependencies": {
-				"ansi-styles": "^4.0.0",
-				"string-width": "^4.1.0",
-				"strip-ansi": "^6.0.0"
+				"ansi-styles": "^6.2.1",
+				"string-width": "^7.0.0",
+				"strip-ansi": "^7.1.0"
 			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/ansi-regex": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/ansi-styles": {
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+			"integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/emoji-regex": {
+			"version": "10.6.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+			"integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+			"license": "MIT"
+		},
+		"node_modules/wrap-ansi/node_modules/string-width": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+			"integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^10.3.0",
+				"get-east-asian-width": "^1.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/strip-ansi": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.2.2"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
 			}
 		},
 		"node_modules/xtend": {
@@ -10059,42 +9989,94 @@
 			}
 		},
 		"node_modules/yaml": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
-			"integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+			"integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
 			"license": "ISC",
 			"bin": {
 				"yaml": "bin.mjs"
 			},
 			"engines": {
-				"node": ">= 14"
+				"node": ">= 14.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/eemeli"
 			}
 		},
 		"node_modules/yargs": {
-			"version": "17.7.2",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+			"version": "18.0.0",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+			"integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
 			"license": "MIT",
 			"dependencies": {
-				"cliui": "^8.0.1",
+				"cliui": "^9.0.1",
 				"escalade": "^3.1.1",
 				"get-caller-file": "^2.0.5",
-				"require-directory": "^2.1.1",
-				"string-width": "^4.2.3",
+				"string-width": "^7.2.0",
 				"y18n": "^5.0.5",
-				"yargs-parser": "^21.1.1"
+				"yargs-parser": "^22.0.0"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": "^20.19.0 || ^22.12.0 || >=23"
 			}
 		},
 		"node_modules/yargs-parser": {
-			"version": "21.1.1",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+			"version": "22.0.0",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+			"integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
 			"license": "ISC",
 			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=23"
+			}
+		},
+		"node_modules/yargs/node_modules/ansi-regex": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+			"license": "MIT",
+			"engines": {
 				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/yargs/node_modules/emoji-regex": {
+			"version": "10.6.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+			"integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+			"license": "MIT"
+		},
+		"node_modules/yargs/node_modules/string-width": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+			"integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^10.3.0",
+				"get-east-asian-width": "^1.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/yargs/node_modules/strip-ansi": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.2.2"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
 			}
 		},
 		"node_modules/yocto-queue": {
@@ -10115,18 +10097,6 @@
 			"resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
 			"integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
 			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/yoctocolors-cjs": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.2.tgz",
-			"integrity": "sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"

--- a/src/decorators/$index.ts
+++ b/src/decorators/$index.ts
@@ -22,14 +22,20 @@ interface AccessPattern {
 	};
 }
 
+// Visibility templates (Create<T> / Update<T>, @typespec/compiler >= 1.13)
+// re-apply decorators to mutated clones of the model. The access pattern's
+// property references still point at the original model, so a mismatch means
+// "this is a clone, not an entity" — signal the caller to skip it.
 const extractFieldNames = (target: Model, prop: Tuple) => {
 	const values: string[] = [];
 
 	for (const value of (prop as Tuple).values) {
 		assert(
-			value.kind === "ModelProperty" && value.model === target,
+			value.kind === "ModelProperty",
 			"Access patterns must use properties from the model",
 		);
+
+		if (value.model !== target) return undefined;
 
 		values.push(value.name);
 	}
@@ -70,21 +76,26 @@ const normalizeKey = (
 		keyName === "pk" && isLocalSecondaryIndex(index) ? "" : index;
 
 	if (key && key.kind === "Tuple") {
+		const composite = extractFieldNames(target, key);
+		if (composite === undefined) return undefined;
+
 		return {
 			field: `${fieldPrefix}${keyName}`,
-			composite: extractFieldNames(target, key),
+			composite,
 		};
 	}
 
 	if (key && key.kind === "Model") {
 		const composite = getProperty(key, "composite");
+		const fields =
+			composite && composite.kind === "Tuple"
+				? extractFieldNames(target, composite)
+				: [];
+		if (fields === undefined) return undefined;
 
 		return {
 			field: getStringValue(key, "field"),
-			composite:
-				composite && composite.kind === "Tuple"
-					? extractFieldNames(target, composite)
-					: [],
+			composite: fields,
 		};
 	}
 
@@ -101,9 +112,14 @@ export function $index(
 	pattern: Model,
 ) {
 	const name = patternName.value;
+	const pk = normalizeKey("pk", { target, pattern });
+	const sk = normalizeKey("sk", { target, pattern });
+
+	if (pk === undefined || sk === undefined) return;
+
 	const accesPattern: AccessPattern = {
-		pk: normalizeKey("pk", { target, pattern }),
-		sk: normalizeKey("sk", { target, pattern }),
+		pk,
+		sk,
 	};
 
 	for (const key of ["index", "collection", "type", "scope"] as const) {

--- a/test/main.tsp
+++ b/test/main.tsp
@@ -167,3 +167,11 @@ model Document {
     typedPayload: Record<Contact>;
     metadata: Address;
 }
+
+// Regression for visibility-mutated clones (@typespec/compiler >= 1.13):
+// Create<T> re-applies @entity/@index to a mutated clone whose properties
+// differ from the originals referenced in the access patterns. The decorator
+// must skip the clone instead of crashing.
+model PersonCreateParams {
+    ...Create<Person>;
+}


### PR DESCRIPTION
## Problem

With `@typespec/compiler` >= 1.13, lifecycle visibility templates (`Create<T>` / `Update<T>`) are implemented through the mutator framework, which re-applies decorators to mutated clones of the model. A clone's properties are filtered/renamed, while the `@index` access pattern's property references still point at the original model. The `assert(value.model === target)` in `extractFieldNames` then crashes the entire compilation:

```
AssertionError [ERR_ASSERTION]: Access patterns must use properties from the model
    at extractFieldNames (src/decorators/$index.ts:29:3)
    ...
    at mutateSubgraphWorker (@typespec/compiler/src/experimental/mutators.ts)
```

Any spec that both declares `@entity`/`@index` models and derives params via `...Create<T>` fails to compile.

## Fix

A property reference whose `model` is not the decorator target means the decorator is running against a mutated clone, not the entity declaration. Skip registering the access pattern for the clone instead of asserting. The original application (where references and target match) is unchanged.

## Tests

- `test/main.tsp` gains `model PersonCreateParams { ...Create<Person>; }` — reproduces the crash before the fix (Person has an `@invisible(Lifecycle)` pk, so the Create mutation drops a key property).
- Lockfile updated so the suite runs against `@typespec/compiler` 1.13.
- Full suite passes (71 tests).