### PR TITLE
fix: support EnumMember type kind in electrodb emitter

### DIFF
--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -2,6 +2,7 @@ import assert from "node:assert";
 import type {
 	ArrayModelType,
 	Enum,
+	EnumMember,
 	Model,
 	ModelProperty,
 	RecordModelType,
@@ -382,6 +383,26 @@ function emitEnumModel(type: Enum): Attribute {
 	};
 }
 
+/**
+ * Emits a single enum member as a single-value enum.
+ *
+ * This handles generic instantiations such as `RefDataLink<RefDataKind.Currency>`,
+ * where a property typed `refDataKind: Kind` resolves to an EnumMember rather than
+ * the parent Enum. Emitting a one-element value list pins the attribute to the single
+ * valid value while preserving the generic's per-kind narrowing.
+ *
+ * The effective value is derived as `value ?? name`, matching @typespec/openapi3's
+ * `enumMemberReference` (and `emitEnumModel` below). Numeric member values are
+ * stringified to keep the array of string values that ElectroDB enums expect — this
+ * matches the rest of this emitter (`emitEnumModel`, `emitArrayModel`) rather than
+ * openapi3, which preserves the numeric type.
+ */
+function emitEnumMember(type: EnumMember): Attribute {
+	return {
+		type: [`${type.value ?? type.name}`],
+	};
+}
+
 function emitTypeToTypeScript(type: Type): string {
 	switch (type.kind) {
 		case "Scalar": {
@@ -433,6 +454,8 @@ function emitTypeToTypeScript(type: Type): string {
 				.join(" | ");
 			return values;
 		}
+		case "EnumMember":
+			return `"${type.value ?? type.name}"`;
 		case "Union": {
 			const variants = Array.from(type.variants.values())
 				.map((variant) => emitTypeToTypeScript(variant.type))
@@ -491,6 +514,8 @@ function emitType(type: Type): Attribute {
 			return emitModel(type);
 		case "Enum":
 			return emitEnumModel(type);
+		case "EnumMember":
+			return emitEnumMember(type);
 		case "Union":
 			return emitUnion(type);
 		default:

--- a/test/entities.test.ts
+++ b/test/entities.test.ts
@@ -1,7 +1,13 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { suite, test } from "node:test";
-import { Document, Job, Person, Task } from "../build/entities/index.mjs";
+import {
+	CreditLimit,
+	Document,
+	Job,
+	Person,
+	Task,
+} from "../build/entities/index.mjs";
 
 suite("Job Entity", () => {
 	test("Job entity has correct model configuration", () => {
@@ -534,5 +540,73 @@ suite("Open Record types (Record<T>)", () => {
 			type: ["NL", "US", "DE"],
 			required: true,
 		});
+	});
+});
+
+suite("Enum member types (RefDataLink<Kind>)", () => {
+	// A generic model property typed to its type parameter (refDataKind: Kind)
+	// resolves to an EnumMember when instantiated as RefDataLink<RefDataKind.Currency>.
+	// It must emit as a single-value enum, not crash on an unsupported type kind.
+	test("currency is a closed map with code and refDataKind", () => {
+		assert.equal(CreditLimit.attributes.currency.type, "map");
+		assert.equal(CreditLimit.attributes.currency.required, true);
+	});
+
+	test("refDataKind enum-member emits as a single-value enum", () => {
+		assert.deepEqual(CreditLimit.attributes.currency.properties.refDataKind, {
+			type: ["Currency"],
+			required: true,
+		});
+	});
+
+	test("code property remains a plain string", () => {
+		assert.deepEqual(CreditLimit.attributes.currency.properties.code, {
+			type: "string",
+			required: true,
+		});
+	});
+
+	test("direct (non-generic) enum-member typing emits a single-value enum", () => {
+		assert.deepEqual(CreditLimit.attributes.directKind, {
+			type: ["Unit"],
+			required: true,
+		});
+	});
+
+	test("string-valued enum member emits the value, not the name", () => {
+		assert.deepEqual(CreditLimit.attributes.settlementCurrency, {
+			type: ["eur"],
+			required: true,
+		});
+	});
+
+	test("numeric-valued enum member is stringified", () => {
+		assert.deepEqual(CreditLimit.attributes.cutoffDay, {
+			type: ["1"],
+			required: true,
+		});
+	});
+
+	test("Record<EnumMember> emits an open 'any' attribute", () => {
+		assert.deepEqual(CreditLimit.attributes.kindLookup, {
+			type: "any",
+			required: true,
+		});
+	});
+
+	test("Record<EnumMember> routes through emitTypeToTypeScript without crashing", () => {
+		const source = readFileSync(
+			new URL("../build/entities/index.mjs", import.meta.url),
+			"utf8",
+		);
+		// An EnumMember Record value type flows through emitTypeToTypeScript's
+		// EnumMember case. The TS literal it produces is the generic argument of
+		// CustomAttributeType, which transpilation erases, so we assert the
+		// CustomAttributeType call was emitted (i.e. the path did not fall through
+		// to the unsupported-type default).
+		assert.match(
+			source,
+			/kindLookup:\s*\{\s*type:\s*CustomAttributeType\("any"\)/,
+		);
 	});
 });

--- a/test/main.tsp
+++ b/test/main.tsp
@@ -168,6 +168,61 @@ model Document {
     metadata: Address;
 }
 
+// Regression for enum-member-typed properties (e.g. RefDataLink<Kind>):
+// A generic model whose property is typed to the type parameter resolves to an
+// EnumMember (not the parent Enum) when instantiated. The emitter must emit it
+// as a single-value enum instead of crashing on the unsupported type kind.
+enum RefDataKind {
+    Country,
+    Currency,
+    Unit,
+}
+
+model RefDataLink<Kind extends RefDataKind> {
+    code: string;
+    refDataKind: Kind;
+}
+
+// String-valued enum: members carry an explicit value distinct from their name,
+// so an enum-member type must emit the value ("eur"), not the name ("Euro").
+enum CurrencyCode {
+    Euro: "eur",
+    Dollar: "usd",
+}
+
+// Numeric-valued enum: pins the (intentional) stringification of numeric member
+// values — a member typed as DayOfWeek.Monday must emit ["1"], not [1].
+enum DayOfWeek {
+    Monday: 1,
+    Tuesday: 2,
+}
+
+@entity("creditLimit", "org")
+@index(
+    "creditLimits",
+    {
+        pk: [CreditLimit.pk],
+    }
+)
+model CreditLimit {
+    pk: UUID;
+
+    // Generic instantiation → EnumMember (the originally reported crash).
+    currency: RefDataLink<RefDataKind.Currency>;
+
+    // Direct (non-generic) enum-member typing → also an EnumMember.
+    directKind: RefDataKind.Unit;
+
+    // Enum member with an explicit string value → emits the value.
+    settlementCurrency: CurrencyCode.Euro;
+
+    // Enum member with a numeric value → stringified.
+    cutoffDay: DayOfWeek.Monday;
+
+    // EnumMember reaching emitTypeToTypeScript via an open Record value type.
+    kindLookup: Record<RefDataKind.Country>;
+}
+
 // Regression for visibility-mutated clones (@typespec/compiler >= 1.13):
 // Create<T> re-applies @entity/@index to a mutated clone whose properties
 // differ from the originals referenced in the access patterns. The decorator


### PR DESCRIPTION
## Summary

The emitter crashes with `Type kind EnumMember is currently not supported!` whenever a property resolves to a TypeSpec **`EnumMember`** rather than an `Enum`. This happens with generic models such as:

```tsp
model RefDataLink<Kind extends RefDataKind> {
  code: string;
  refDataKind: Kind;   // instantiated as RefDataLink<RefDataKind.Currency> -> EnumMember
}
```

`emitType` only handled `Scalar | Model | Enum | Union` and threw on everything else, so `RefDataLink<Kind>` (and any directly enum-member-typed property) could not be persisted on a DynamoDB entity. The `openapi3`, `zod`, and `opensearch` emitters all handle enum-members fine — only `electrodb` didn't.

## Fix

Add an `emitEnumMember` case to both `emitType` and `emitTypeToTypeScript`, emitting the member as a **single-value enum** (`{ type: [value ?? name] }`). This:

- mirrors `@typespec/openapi3`'s `enumMemberReference` value derivation and the existing `emitEnumModel` representation,
- preserves the generic's per-kind narrowing (the whole point of `RefDataLink<Kind>`),
- stringifies numeric member values to match this emitter's existing enum handling (`emitEnumModel` / `emitArrayModel`).

## Tests

New fixtures + assertions in `test/main.tsp` / `test/entities.test.ts` covering:

| Case | Asserts |
|---|---|
| Generic instantiation `RefDataLink<RefDataKind.Currency>` | `refDataKind` -> `{ type: ["Currency"] }` (the reported crash) |
| Direct (non-generic) `RefDataKind.Unit` | `{ type: ["Unit"] }` |
| String-valued member `CurrencyCode.Euro` (`Euro: "eur"`) | `{ type: ["eur"] }` — value preferred over name |
| Numeric-valued member `DayOfWeek.Monday` (`Monday: 1`) | `{ type: ["1"] }` — stringified |
| `Record<RefDataKind.Country>` | exercises the `emitTypeToTypeScript` EnumMember path |

## Validation

- `npm run build` (tsc) — pass
- `npm run test:emit` (tsp compile — previously crashed) — pass
- `npm run test:unit` — **79/79 pass**
- `npm run test:types` (tsc) — pass
- `npm run test:biome` — pass

## Notes / follow-up

- Numeric enum-member values are intentionally emitted as strings to stay consistent with the rest of the emitter (DynamoDB/ElectroDB enums are string-value lists). This diverges from openapi3, which preserves the numeric type — documented in the `emitEnumMember` docstring.
- A possible follow-up (out of scope here): extract a shared `enumMemberLiteral()` helper used by `emitEnumModel`, `emitArrayModel`, and `emitEnumMember` so the value-derivation/coercion convention lives in one place.
