### PR TITLE
ci: enable native auto-merge for trusted PRs

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,31 @@
+name: Auto-merge
+
+# Turns on GitHub's native auto-merge for trusted PRs. The branch ruleset
+# (required checks + review-thread resolution) still gates the actual merge,
+# so a PR only lands once it is green and all threads are resolved.
+
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review, synchronize]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  enable-auto-merge:
+    runs-on: ubuntu-latest
+    if: >-
+      !github.event.pull_request.draft &&
+      (
+        github.event.pull_request.author_association == 'OWNER' ||
+        github.event.pull_request.author_association == 'MEMBER' ||
+        github.event.pull_request.author_association == 'COLLABORATOR' ||
+        github.event.pull_request.user.login == 'dependabot[bot]'
+      )
+    steps:
+      - name: Enable squash auto-merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge "$PR_URL" --squash --auto


### PR DESCRIPTION
Adds a workflow that turns on GitHub's native auto-merge for PRs from the owner, members, collaborators, and dependabot.

The branch ruleset still gates the merge — required checks (`build (22.x)`/`build (24.x)`) must pass and all review threads must be resolved before anything lands. Fork PRs from outside contributors are not auto-enabled.

This is the missing piece behind #39, which sat green-but-unmerged because auto-merge was never enabled.