### PR TITLE
fix: named open-record model emits 'any' instead of stripping map (#41)

### DIFF
--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -362,12 +362,22 @@ function emitOpenRecordModel(type: RecordModelType): Attribute {
 	};
 }
 
+function isOpenRecordModel(type: Model): boolean {
+	return (
+		type.indexer?.key?.name === "string" &&
+		[...walkPropertiesInherited(type)].length === 0
+	);
+}
+
 function emitModel(type: Model): Attribute {
 	switch (type.name) {
 		case "Array":
 			return emitArrayModel(type as ArrayModelType);
 		case "Record":
 			return emitOpenRecordModel(type as RecordModelType);
+	}
+	if (isOpenRecordModel(type)) {
+		return emitOpenRecordModel(type as RecordModelType);
 	}
 	return emitRecordModel(type as RecordModelType);
 }

--- a/test/entities.test.ts
+++ b/test/entities.test.ts
@@ -524,6 +524,13 @@ suite("Open Record types (Record<T>)", () => {
 		assert.match(source, /payload: \{\s*type: CustomAttributeType\("any"\)/);
 	});
 
+	test("named open-record model emits an open 'any' attribute, not a stripping map", () => {
+		assert.deepEqual(Document.attributes.namedPayload, {
+			type: "any",
+			required: true,
+		});
+	});
+
 	test("named model property still emits a closed map with its properties", () => {
 		assert.equal(Document.attributes.metadata.type, "map");
 		assert.deepEqual(Document.attributes.metadata.properties.street, {

--- a/test/main.tsp
+++ b/test/main.tsp
@@ -154,6 +154,8 @@ model Person {
     coffeePreferences: CoffeePreferences[];
 }
 
+model JsonSchemaObject is Record<unknown>;
+
 @entity("document", "org")
 @index(
     "documents",
@@ -165,6 +167,7 @@ model Document {
     pk: UUID;
     payload: Record<unknown>;
     typedPayload: Record<Contact>;
+    namedPayload: JsonSchemaObject;
     metadata: Address;
 }
 


### PR DESCRIPTION
A named model whose body is just an open record (`model Foo is Record<unknown>`) was routed to the closed-map path and emitted as `{ type: "map", properties: {} }`. ElectroDB reads an empty-properties map as a fully-declared structured map with no allowed keys, so it silently strips every key on write — the data is lost. Only the anonymous `Record<unknown>` form worked, even though a named alias is the more natural thing to reach for.

The fix detects a named model that is itself an open record (string indexer, no own properties) and routes it to the same `CustomAttributeType<...>("any")` path as the anonymous form.

Closes #41