### PR TITLE
feat: add @semanticVersion decorator for DynamoDB sort-key ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ Install this generator in your typespec project:
 
 `npm i -D  typespec-electrodb-emitter`
 
-Then, annotate your models using `@entity`, `@index`, `@createdAt`, `@updatedAt`, `@label`
+Then, annotate your models using `@entity`, `@index`, `@createdAt`, `@updatedAt`, `@label`, `@semanticVersion`
 
 ## Example
 
-Take a peek at the [./demo/main.tsp](./demo/main.tsp) for an of how this works:
+Take a peek at [./test/main.tsp](./test/main.tsp) for a full example of how this works:
 
 ```typespec
 import "typespec-electrodb-emitter";
@@ -219,6 +219,51 @@ export declare const Person: {
     };
 };
 ```
+
+## Sorting semantic versions (`@semanticVersion`)
+
+DynamoDB compares sort keys byte-lexicographically, not numerically, so a
+semantic-version string stored as-is sorts wrong the moment any segment
+reaches two digits: `"1.10.0" < "1.9.0"`. `@semanticVersion` marks a property
+so the generated ElectroDB attribute zero-pads each dot-separated segment on
+write and reverses it on read — callers only ever see the plain `"1.10.0"`
+string, but a sort key carrying this attribute now sorts in true
+semantic-version order, so "give me the highest version" is a native
+`ScanIndexForward:false, Limit:1` query instead of a hand-maintained "latest"
+marker row.
+
+Apply it to a property typed as (or extending) the `SemanticVersion` scalar
+this library exports:
+
+```typespec
+import "typespec-electrodb-emitter";
+
+@entity("productRelease", "catalog")
+@index(
+    "releases",
+    {
+        pk: [ProductRelease.productCode],
+        sk: [ProductRelease.version],
+    }
+)
+model ProductRelease {
+    productCode: string;
+
+    @semanticVersion
+    version: SemanticVersion;
+}
+```
+
+```typescript
+// Highest version for a product, no marker entity or app-level compare:
+await ProductReleaseEntity.query
+    .releases({ productCode: "widget" })
+    .go({ order: "desc", limit: 1 });
+```
+
+Applying `@semanticVersion` to a property whose type isn't (or doesn't
+extend) a string matching the semantic-version pattern is a compile-time
+error — it only ever touches genuine semver fields, not arbitrary strings.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -264,6 +264,10 @@ await ProductReleaseEntity.query
 Applying `@semanticVersion` to a property whose type isn't (or doesn't
 extend) a string matching the semantic-version pattern is a compile-time
 error — it only ever touches genuine semver fields, not arbitrary strings.
+Each dot-separated segment is capped at 6 digits (0-999999), matching the
+zero-pad width the encoder uses; a scalar whose pattern allows a wider
+segment is rejected at compile time rather than silently mis-sorting once a
+segment overflows the pad.
 
 ## Documentation
 

--- a/src/decorators/$semanticVersion.ts
+++ b/src/decorators/$semanticVersion.ts
@@ -14,7 +14,7 @@ import { reportDiagnostic, StateKeys } from "../lib.js";
  * hand-rolling an equivalent regex.
  */
 export const SEMANTIC_VERSION_PATTERN =
-	"^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$";
+	"^(0|[1-9]\\d{0,5})\\.(0|[1-9]\\d{0,5})\\.(0|[1-9]\\d{0,5})$";
 
 function hasSemanticVersionPattern(
 	program: Program,

--- a/src/decorators/$semanticVersion.ts
+++ b/src/decorators/$semanticVersion.ts
@@ -1,0 +1,53 @@
+import type {
+	DecoratorContext,
+	ModelProperty,
+	Program,
+	Scalar,
+} from "@typespec/compiler";
+import { getPattern } from "@typespec/compiler";
+import { reportDiagnostic, StateKeys } from "../lib.js";
+
+/**
+ * Canonical semantic-version pattern. `@semanticVersion` only accepts a
+ * property whose own `@pattern` (or its scalar type's) matches this exactly —
+ * use the `SemanticVersion` scalar exported by this library rather than
+ * hand-rolling an equivalent regex.
+ */
+export const SEMANTIC_VERSION_PATTERN =
+	"^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$";
+
+function hasSemanticVersionPattern(
+	program: Program,
+	target: ModelProperty,
+): boolean {
+	if (getPattern(program, target) === SEMANTIC_VERSION_PATTERN) {
+		return true;
+	}
+
+	if (target.type.kind !== "Scalar") return false;
+
+	let scalar: Scalar | undefined = target.type;
+	while (scalar) {
+		if (getPattern(program, scalar) === SEMANTIC_VERSION_PATTERN) {
+			return true;
+		}
+		scalar = scalar.baseScalar;
+	}
+
+	return false;
+}
+
+export function $semanticVersion(
+	context: DecoratorContext,
+	target: ModelProperty,
+) {
+	if (!hasSemanticVersionPattern(context.program, target)) {
+		reportDiagnostic(context.program, {
+			code: "semantic-version-invalid-type",
+			target,
+		});
+		return;
+	}
+
+	context.program.stateSet(StateKeys.semanticVersion).add(target);
+}

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -698,6 +698,28 @@ function emitAttribute(ctx: EmitContext, prop: ModelProperty): Attribute {
 		attr.validate = validateFn;
 	}
 
+	if (ctx.program.stateSet(StateKeys.semanticVersion).has(prop)) {
+		assert(attr.type === "string", "@semanticVersion must be a string");
+
+		// @ts-expect-error - set is a valid ElectroDB attribute property
+		attr.set = (val?: string) => {
+			if (val === undefined) return val;
+			return val
+				.split(".")
+				.map((segment) => segment.padStart(5, "0"))
+				.join(".");
+		};
+
+		// @ts-expect-error - get is a valid ElectroDB attribute property
+		attr.get = (val?: string) => {
+			if (val === undefined) return val;
+			return val
+				.split(".")
+				.map((segment) => String(Number(segment)))
+				.join(".");
+		};
+	}
+
 	return attr;
 }
 

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -706,7 +706,7 @@ function emitAttribute(ctx: EmitContext, prop: ModelProperty): Attribute {
 			if (val === undefined) return val;
 			return val
 				.split(".")
-				.map((segment) => segment.padStart(5, "0"))
+				.map((segment) => segment.padStart(6, "0"))
 				.join(".");
 		};
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ export * from "./decorators/$createdAt.js";
 export * from "./decorators/$entity.js";
 export * from "./decorators/$index.js";
 export * from "./decorators/$label.js";
+export * from "./decorators/$semanticVersion.js";
 export * from "./decorators/$updatedAt.js";
 export * from "./emitter.js";
 export { $lib } from "./lib.js";

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -23,7 +23,17 @@ const EmitterOptionsSchema: JSONSchemaType<EmitterOptions> = {
 
 export const $lib = createTypeSpecLibrary({
 	name: "myLibrary",
-	diagnostics: {},
+	diagnostics: {
+		"semantic-version-invalid-type": {
+			severity: "error",
+			description:
+				"The @semanticVersion decorator requires a string type matching the semantic version pattern.",
+			messages: {
+				default:
+					"@semanticVersion can only be applied to a property typed as (or extending) a string matching the semantic version pattern, e.g. the `SemanticVersion` scalar exported by this library.",
+			},
+		},
+	},
 	state: {
 		electroEntity: { description: "State for the @electroEntity decorator" },
 		label: { description: "State for the @label decorator" },
@@ -31,6 +41,9 @@ export const $lib = createTypeSpecLibrary({
 		updatedAt: { description: "State for the @updatedAt decorator" },
 		partitionKey: { description: "State for the @partitionKey decorator" },
 		index: { description: "State for the @index decorator" },
+		semanticVersion: {
+			description: "State for the @semanticVersion decorator",
+		},
 	},
 	emitter: {
 		options: EmitterOptionsSchema,

--- a/test/fixtures/invalid-semantic-version.tsp
+++ b/test/fixtures/invalid-semantic-version.tsp
@@ -1,0 +1,10 @@
+import "typespec-electrodb-emitter";
+
+// @semanticVersion applied to a plain string (no semver @pattern) must be a
+// compile-time diagnostic, not a silent no-op.
+model BadVersion {
+    pk: string;
+
+    @semanticVersion
+    version: string;
+}

--- a/test/fixtures/oversized-semantic-version.tsp
+++ b/test/fixtures/oversized-semantic-version.tsp
@@ -1,0 +1,17 @@
+import "typespec-electrodb-emitter";
+
+// @semanticVersion's canonical pattern caps each dot-separated segment at 6
+// digits (0-999999) to match the zero-pad width the encoder uses. A scalar
+// with a looser pattern — one that would accept a segment like "1000000" —
+// isn't the exact canonical pattern, so applying @semanticVersion to it must
+// be a compile-time error rather than reaching codegen and silently
+// mis-sorting once a segment overflows the pad.
+@pattern("^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$")
+scalar UnboundedVersion extends string;
+
+model OversizedVersion {
+    pk: string;
+
+    @semanticVersion
+    version: UnboundedVersion;
+}

--- a/test/main.tsp
+++ b/test/main.tsp
@@ -233,3 +233,25 @@ model CreditLimit {
 model PersonCreateParams {
     ...Create<Person>;
 }
+
+// @semanticVersion on a sort key: DynamoDB compares sort keys
+// byte-lexicographically, so a plain semver string sorts wrong past
+// single-digit segments ("1.10.0" < "1.9.0"). Zero-padding each segment on
+// write makes a native `ScanIndexForward:false, Limit:1` query answer
+// "give me the latest version" directly, with no marker entity to maintain.
+@entity("productRelease", "catalog")
+@index(
+    "releases",
+    {
+        pk: [ProductRelease.productCode],
+        sk: [ProductRelease.version],
+    }
+)
+model ProductRelease {
+    productCode: string;
+
+    @semanticVersion
+    version: SemanticVersion;
+
+    releaseNotes?: string;
+}

--- a/test/semantic-version.test.ts
+++ b/test/semantic-version.test.ts
@@ -17,18 +17,18 @@ suite("@semanticVersion decorator", () => {
 			assert.equal(typeof attr.get, "function");
 		});
 
-		test("set zero-pads each dot-separated segment to 5 digits", () => {
+		test("set zero-pads each dot-separated segment to 6 digits", () => {
 			const { set } = ProductRelease.attributes.version;
-			assert.equal(set("1.10.0"), "00001.00010.00000");
-			assert.equal(set("1.9.0"), "00001.00009.00000");
-			assert.equal(set("2.0.0"), "00002.00000.00000");
-			assert.equal(set("1.2.0"), "00001.00002.00000");
+			assert.equal(set("1.10.0"), "000001.000010.000000");
+			assert.equal(set("1.9.0"), "000001.000009.000000");
+			assert.equal(set("2.0.0"), "000002.000000.000000");
+			assert.equal(set("1.2.0"), "000001.000002.000000");
 		});
 
 		test("get reverses the padding back to the plain semver string", () => {
 			const { get } = ProductRelease.attributes.version;
-			assert.equal(get("00001.00010.00000"), "1.10.0");
-			assert.equal(get("00002.00000.00000"), "2.0.0");
+			assert.equal(get("000001.000010.000000"), "1.10.0");
+			assert.equal(get("000002.000000.000000"), "2.0.0");
 		});
 
 		test("round-trips losslessly: get(set(x)) === x for any valid semver string", () => {
@@ -41,7 +41,7 @@ suite("@semanticVersion decorator", () => {
 				"0.0.1",
 				"0.0.0",
 				"10.20.30",
-				"99999.99999.99999",
+				"999999.999999.999999",
 			]) {
 				assert.equal(get(set(version)), version);
 			}
@@ -125,30 +125,51 @@ suite("@semanticVersion decorator", () => {
 	);
 });
 
+function compileFixtureExpectingFailure(fixturePath: string): string {
+	let combinedOutput = "";
+
+	assert.throws(
+		() =>
+			execFileSync(
+				tspBin,
+				["compile", fixturePath, "--config", "test/tspconfig.yaml"],
+				{
+					stdio: "pipe",
+				},
+			),
+		(error: unknown) => {
+			assert.ok(error instanceof Error);
+			const { stdout, stderr } = error as { stdout?: Buffer; stderr?: Buffer };
+			// TypeSpec's diagnostic text isn't guaranteed to land on a single
+			// stream, so check both rather than assuming stdout.
+			combinedOutput = `${String(stdout ?? "")}${String(stderr ?? "")}`;
+			return true;
+		},
+	);
+
+	return combinedOutput;
+}
+
 suite("@semanticVersion compile-time diagnostic", () => {
 	test("applying @semanticVersion to a non-semver-typed property is a compile-time error, not a silent no-op", () => {
-		assert.throws(
-			() =>
-				execFileSync(
-					tspBin,
-					[
-						"compile",
-						"test/fixtures/invalid-semantic-version.tsp",
-						"--config",
-						"test/tspconfig.yaml",
-					],
-					{ stdio: "pipe" },
-				),
-			(error: unknown) => {
-				assert.ok(error instanceof Error);
-				const output = String((error as { stdout?: Buffer }).stdout ?? "");
-				assert.match(output, /myLibrary\/semantic-version-invalid-type/);
-				assert.match(
-					output,
-					/@semanticVersion can only be applied to a property typed as \(or extending\) a string matching the semantic version pattern/,
-				);
-				return true;
-			},
+		const output = compileFixtureExpectingFailure(
+			"test/fixtures/invalid-semantic-version.tsp",
+		);
+		assert.match(output, /myLibrary\/semantic-version-invalid-type/);
+		assert.match(
+			output,
+			/@semanticVersion can only be applied to a property typed as \(or extending\) a string matching the semantic version pattern/,
+		);
+	});
+
+	test("applying @semanticVersion to a scalar whose pattern allows a segment beyond 6 digits is a compile-time error", () => {
+		const output = compileFixtureExpectingFailure(
+			"test/fixtures/oversized-semantic-version.tsp",
+		);
+		assert.match(output, /myLibrary\/semantic-version-invalid-type/);
+		assert.match(
+			output,
+			/@semanticVersion can only be applied to a property typed as \(or extending\) a string matching the semantic version pattern/,
 		);
 	});
 });

--- a/test/semantic-version.test.ts
+++ b/test/semantic-version.test.ts
@@ -1,0 +1,154 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { suite, test } from "node:test";
+import { Entity } from "electrodb";
+import { ProductRelease } from "../build/entities/index.mjs";
+
+const table = "test-table";
+const tspBin = new URL("../node_modules/.bin/tsp", import.meta.url).pathname;
+
+suite("@semanticVersion decorator", () => {
+	suite("generated attribute", () => {
+		test("emits a string attribute with set and get transform functions", () => {
+			const attr = ProductRelease.attributes.version;
+			assert.equal(attr.type, "string");
+			assert.equal(attr.required, true);
+			assert.equal(typeof attr.set, "function");
+			assert.equal(typeof attr.get, "function");
+		});
+
+		test("set zero-pads each dot-separated segment to 5 digits", () => {
+			const { set } = ProductRelease.attributes.version;
+			assert.equal(set("1.10.0"), "00001.00010.00000");
+			assert.equal(set("1.9.0"), "00001.00009.00000");
+			assert.equal(set("2.0.0"), "00002.00000.00000");
+			assert.equal(set("1.2.0"), "00001.00002.00000");
+		});
+
+		test("get reverses the padding back to the plain semver string", () => {
+			const { get } = ProductRelease.attributes.version;
+			assert.equal(get("00001.00010.00000"), "1.10.0");
+			assert.equal(get("00002.00000.00000"), "2.0.0");
+		});
+
+		test("round-trips losslessly: get(set(x)) === x for any valid semver string", () => {
+			const { set, get } = ProductRelease.attributes.version;
+			for (const version of [
+				"1.9.0",
+				"1.10.0",
+				"2.0.0",
+				"1.2.0",
+				"0.0.1",
+				"0.0.0",
+				"10.20.30",
+				"99999.99999.99999",
+			]) {
+				assert.equal(get(set(version)), version);
+			}
+		});
+
+		test("set and get are no-ops for undefined (optional/absent values)", () => {
+			const { set, get } = ProductRelease.attributes.version;
+			assert.equal(set(undefined), undefined);
+			assert.equal(get(undefined), undefined);
+		});
+
+		test("validates the semver pattern from the SemanticVersion scalar's @pattern", () => {
+			const { validate } = ProductRelease.attributes.version;
+			assert.equal(validate("1.10.0"), true);
+			assert.throws(
+				() => validate("not-a-version"),
+				/'version' must match pattern/,
+			);
+		});
+	});
+
+	suite(
+		"native sort order under DynamoDB byte-lexicographic comparison",
+		() => {
+			// The lexicographic trap: an unpadded string sort puts "1.10.0" before
+			// "1.9.0" and "1.2.0" because '1' < '9' and '1' < '2' at the first
+			// differing byte. Zero-padding each segment makes byte comparison agree
+			// with semantic-version comparison.
+			const trapVersions = ["1.9.0", "1.10.0", "2.0.0", "1.2.0"];
+
+			test("encoded values sort ascending in true semver order, not lexicographic order", () => {
+				const { set } = ProductRelease.attributes.version;
+				const ascending = [...trapVersions].sort((a, b) =>
+					set(a) < set(b) ? -1 : set(a) > set(b) ? 1 : 0,
+				);
+
+				assert.deepEqual(ascending, ["1.2.0", "1.9.0", "1.10.0", "2.0.0"]);
+			});
+
+			test("a descending range query (ScanIndexForward:false) returns real semver order", () => {
+				const ProductReleaseEntity = new Entity(ProductRelease, { table });
+
+				// Build the items exactly as ElectroDB would persist them (sort key
+				// carries the zero-padded, encoded version).
+				const items = trapVersions.map(
+					(version) =>
+						ProductReleaseEntity.put({
+							productCode: "widget",
+							version,
+						}).params().Item,
+				);
+
+				// DynamoDB's ScanIndexForward:false / order:"desc" is a descending
+				// byte-lexicographic sort of the sort key ("sk") — simulate it here.
+				const descendingBySortKey = [...items].sort((a, b) =>
+					a.sk < b.sk ? 1 : a.sk > b.sk ? -1 : 0,
+				);
+
+				const highestFirst = descendingBySortKey.map((item) => {
+					const { data } = ProductReleaseEntity.parse({ Item: item });
+					assert.ok(data);
+					return data.version;
+				});
+
+				// Real semantic-version descending order, not lexicographic order
+				// (which would incorrectly put "1.9.0" ahead of "1.10.0" and "2.0.0").
+				assert.deepEqual(highestFirst, ["2.0.0", "1.10.0", "1.9.0", "1.2.0"]);
+			});
+
+			test("the highest version is the first result (Limit:1 semantics)", () => {
+				const { set } = ProductRelease.attributes.version;
+				const highest = trapVersions
+					.map((version) => ({ version, encoded: set(version) }))
+					.sort((a, b) =>
+						a.encoded < b.encoded ? 1 : a.encoded > b.encoded ? -1 : 0,
+					)[0];
+
+				assert.equal(highest.version, "2.0.0");
+			});
+		},
+	);
+});
+
+suite("@semanticVersion compile-time diagnostic", () => {
+	test("applying @semanticVersion to a non-semver-typed property is a compile-time error, not a silent no-op", () => {
+		assert.throws(
+			() =>
+				execFileSync(
+					tspBin,
+					[
+						"compile",
+						"test/fixtures/invalid-semantic-version.tsp",
+						"--config",
+						"test/tspconfig.yaml",
+					],
+					{ stdio: "pipe" },
+				),
+			(error: unknown) => {
+				assert.ok(error instanceof Error);
+				const output = String((error as { stdout?: Buffer }).stdout ?? "");
+				assert.match(output, /myLibrary\/semantic-version-invalid-type/);
+				assert.match(
+					output,
+					/@semanticVersion can only be applied to a property typed as \(or extending\) a string matching the semantic version pattern/,
+				);
+				return true;
+			},
+		);
+	});
+});

--- a/tsp/main.tsp
+++ b/tsp/main.tsp
@@ -54,8 +54,12 @@ extern dec updatedAt(target: ModelProperty, label?: string);
  * sort keys byte-lexicographically, which sorts a semver string incorrectly
  * once any segment reaches two digits ("1.10.0" < "1.9.0"). `@semanticVersion`
  * stores this value zero-padded so plain range queries sort correctly.
+ *
+ * Each dot-separated segment is capped at 6 digits (0-999999) to match the
+ * zero-pad width `@semanticVersion` encodes with — a segment beyond that is
+ * a compile-time error rather than a value that silently sorts incorrectly.
  */
-@pattern("^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$")
+@pattern("^(0|[1-9]\\d{0,5})\\.(0|[1-9]\\d{0,5})\\.(0|[1-9]\\d{0,5})$")
 scalar SemanticVersion extends string;
 
 /**
@@ -63,7 +67,7 @@ scalar SemanticVersion extends string;
  * DynamoDB's byte-lexicographic key comparison.
  *
  * Emits a `set`/`get` transform pair on the generated ElectroDB attribute:
- * `set` zero-pads each dot-separated segment (`"1.10.0"` -> `"00001.00010.00000"`)
+ * `set` zero-pads each dot-separated segment (`"1.10.0"` -> `"000001.000010.000000"`)
  * before persisting, `get` reverses it, so callers always see the plain
  * `"1.10.0"` string. A sort key carrying this attribute answers "give me the
  * highest version" with a native `ScanIndexForward:false, Limit:1` query,
@@ -71,7 +75,8 @@ scalar SemanticVersion extends string;
  *
  * The target property's type must be (or extend) a string scalar matching
  * semantic-version syntax — use the `SemanticVersion` scalar exported by
- * this library. Applying it to any other type is a compile-time error.
+ * this library. Applying it to any other type, or to a scalar whose pattern
+ * allows a segment wider than 6 digits, is a compile-time error.
  */
 extern dec semanticVersion(target: ModelProperty);
 

--- a/tsp/main.tsp
+++ b/tsp/main.tsp
@@ -48,6 +48,34 @@ extern dec createdAt(target: ModelProperty, label?: string);
 extern dec updatedAt(target: ModelProperty, label?: string);
 
 /**
+ * A semantic version string (e.g. "1.10.0"). See https://semver.org.
+ *
+ * Intended for use with `@semanticVersion` on a sort key: DynamoDB compares
+ * sort keys byte-lexicographically, which sorts a semver string incorrectly
+ * once any segment reaches two digits ("1.10.0" < "1.9.0"). `@semanticVersion`
+ * stores this value zero-padded so plain range queries sort correctly.
+ */
+@pattern("^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$")
+scalar SemanticVersion extends string;
+
+/**
+ * Marks a property as a semantic version that must sort correctly under
+ * DynamoDB's byte-lexicographic key comparison.
+ *
+ * Emits a `set`/`get` transform pair on the generated ElectroDB attribute:
+ * `set` zero-pads each dot-separated segment (`"1.10.0"` -> `"00001.00010.00000"`)
+ * before persisting, `get` reverses it, so callers always see the plain
+ * `"1.10.0"` string. A sort key carrying this attribute answers "give me the
+ * highest version" with a native `ScanIndexForward:false, Limit:1` query,
+ * instead of a hand-maintained "latest" marker.
+ *
+ * The target property's type must be (or extend) a string scalar matching
+ * semantic-version syntax — use the `SemanticVersion` scalar exported by
+ * this library. Applying it to any other type is a compile-time error.
+ */
+extern dec semanticVersion(target: ModelProperty);
+
+/**
  * Define an ElectroDB index. See https://electrodb.dev/en/modeling/indexes/
  *
  * Use either shorthand definition:


### PR DESCRIPTION
## Summary

DynamoDB compares sort keys byte-lexicographically, not numerically, so a semantic-version string stored as-is sorts incorrectly the moment any segment reaches two digits (`"1.10.0" < "1.9.0"`). Consumers today work around this with a hand-maintained "latest" marker row and an application-level compare — duplicated, easy-to-get-wrong complexity per entity.

`@semanticVersion` marks a model property so the generated ElectroDB attribute gets a `set`/`get` transform pair: `set` zero-pads each dot-separated segment (5 digits) before persisting, `get` reverses it. Callers only ever see the plain `"1.10.0"` string; the padding is invisible storage plumbing. A sort key carrying this attribute now sorts in true semantic-version order under plain byte comparison, so "give me the highest version" becomes a native `ScanIndexForward:false, Limit:1` query.

The decorator is narrow by design: it only accepts a property whose type is (or extends) a string scalar matching the semantic-version pattern — a library-exported `SemanticVersion` scalar covers this. Applying it to any other type is a compile-time diagnostic, not a silent no-op.

Closes #46

## Test plan

- [x] `npm test` (biome, tsp compile, type-check, unit tests) — all green
- [x] Round-trip test: `get(set(x)) === x` for a range of valid semver strings
- [x] Native sort-order test seeded with the lexicographic trap (`"1.9.0"`, `"1.10.0"`, `"2.0.0"`, `"1.2.0"`), asserting a descending sort-key comparison (simulating `ScanIndexForward:false`) returns true semver order
- [x] Compile-time diagnostic test: applying `@semanticVersion` to a plain (non-semver) string fails compilation with the expected diagnostic code and message
- [x] `test/main.tsp` gained a `ProductRelease` entity demonstrating `@semanticVersion` on a sort key for a "latest version" query