### PR TITLE
fix: emit a set transform so writing an empty enum-array succeeds

### DIFF
--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -331,6 +331,10 @@ function emitArrayModel(type: ArrayModelType): Attribute {
 		return {
 			type: "set",
 			items,
+			// DynamoDB rejects writing an empty Set. Drop the attribute entirely
+			// when the array is empty so the write succeeds instead of throwing.
+			set: (value?: string[]) =>
+				Array.isArray(value) && value.length === 0 ? undefined : value,
 		};
 	}
 

--- a/test/electrodb.test.ts
+++ b/test/electrodb.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { suite, test } from "node:test";
 import { Entity, Service } from "electrodb";
-import { Job, Person, Task } from "../build/entities/index.mjs";
+import { Job, Person, Pet, Task } from "../build/entities/index.mjs";
 
 const table = "test-table";
 
@@ -192,5 +192,33 @@ suite("ElectroDB Service", () => {
 			pk: "1234567890123456789012345",
 		});
 		assert.equal(typeof query.go, "function");
+	});
+});
+
+suite("Pet Entity (set-typed attribute, issue #45)", () => {
+	test("put with an empty tags array does not throw and drops the tags key", () => {
+		const PetEntity = new Entity(Pet, { table });
+
+		const params = PetEntity.put({
+			petId: "1234567890123456789012345",
+			name: "Rex",
+			tags: [],
+		}).params();
+
+		assert.ok(params.Item);
+		assert.equal("tags" in params.Item, false);
+	});
+
+	test("put with a non-empty tags array keeps the tags key", () => {
+		const PetEntity = new Entity(Pet, { table });
+
+		const params = PetEntity.put({
+			petId: "1234567890123456789012345",
+			name: "Rex",
+			tags: ["01", "02"],
+		}).params();
+
+		assert.ok(params.Item);
+		assert.deepEqual([...params.Item.tags.values].sort(), ["01", "02"]);
 	});
 });

--- a/test/entities.test.ts
+++ b/test/entities.test.ts
@@ -393,11 +393,37 @@ suite("Person Entity", () => {
 		});
 
 		test("coffeePreferences has correct full structure", () => {
-			assert.deepEqual(Person.attributes.coffeePreferences, {
+			const { set, ...rest } = Person.attributes.coffeePreferences as {
+				set?: (value?: string[]) => string[] | undefined;
+				[key: string]: unknown;
+			};
+
+			assert.deepEqual(rest, {
 				type: "set",
 				items: ["01", "02", "03"],
 				required: true,
 			});
+			assert.equal(typeof set, "function");
+		});
+
+		test("coffeePreferences has a set transform", () => {
+			assert.equal(typeof Person.attributes.coffeePreferences.set, "function");
+		});
+
+		test("coffeePreferences set transform returns undefined for an empty array", () => {
+			const set = Person.attributes.coffeePreferences.set as (
+				value?: string[],
+			) => string[] | undefined;
+
+			assert.equal(set([]), undefined);
+		});
+
+		test("coffeePreferences set transform passes non-empty arrays through unchanged", () => {
+			const set = Person.attributes.coffeePreferences.set as (
+				value?: string[],
+			) => string[] | undefined;
+
+			assert.deepEqual(set(["01", "02"]), ["01", "02"]);
 		});
 	});
 

--- a/test/main.tsp
+++ b/test/main.tsp
@@ -233,3 +233,25 @@ model CreditLimit {
 model PersonCreateParams {
     ...Create<Person>;
 }
+
+// Regression for issue #45: an enum array ("set" attribute) must accept an
+// empty array on write. DynamoDB rejects empty Sets, so the emitted attribute
+// needs a `set` transform that drops the attribute when the array is empty.
+enum PetTag {
+    Friendly: "01",
+    Playful: "02",
+    Shy: "03",
+}
+
+@entity("pet", "petstore")
+@index(
+    "pets",
+    {
+        pk: [Pet.petId],
+    }
+)
+model Pet {
+    petId: UUID;
+    name: string;
+    tags: PetTag[];
+}


### PR DESCRIPTION
## Summary

DynamoDB rejects writing a Set attribute with zero members. TypeSpec `enum[]` properties are emitted as ElectroDB `"set"` attributes, so writing `[]` (a routine "no tags selected" value) always threw an `ElectroError`.

## Fix

`emitArrayModel` in `src/emitter.ts` now attaches a `set` transform to every `"set"`-typed attribute:

```ts
set: (value?: string[]) =>
  Array.isArray(value) && value.length === 0 ? undefined : value,
```

An empty array is turned into `undefined` before ElectroDB builds the write item, so the attribute is dropped from the write instead of reaching the DynamoDB marshaller. `required: true` and `items` are untouched — a caller must still pass an array, `[]` is legitimate, `undefined` remains a caller bug.

Reads are out of scope per the issue — a row with no stored attribute still parses back as `undefined`, same as any other optional-but-conceptually-required collection.

## Tests

- `test/main.tsp`: added a `Pet`/`tags` fixture mirroring the issue's repro (single valid index, `PetTag[]` enum array).
- `test/entities.test.ts`: asserts the emitted `coffeePreferences` set attribute has a `set` function, that `set([])` returns `undefined`, and `set(["01","02"])` passes through unchanged. Updated the existing "full structure" `deepEqual` test to account for the new `set` key without weakening its other assertions.
- `test/electrodb.test.ts`: real `Entity(Pet, ...).put({ tags: [] }).params()` call asserting `Item` has no `tags` key and no error is thrown, plus a companion test confirming a non-empty `tags` array is preserved in the params.

`npm test` (biome + emit + types + unit) passes: 85/85 tests green.

Fixes #45