### PR TITLE
feat: opt-in per-entity ModelBase class emission (generation-gap pattern)

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,12 +282,12 @@ options:
       config-type: "BaseModelConfig"
 ```
 
-For every `@entity` model (e.g. `Pet`), the emitter generates a standalone module — `pet-model-base.mjs`/`.cjs`/`.d.ts` — that is **not** re-exported from a shared barrel:
+For every `@entity` model (e.g. `Pet`), the emitter generates a standalone module — `pet-model-base.mjs`/`.cjs`/`.d.mts`/`.d.cts` — that is **not** re-exported from a shared barrel:
 
 ```ts
-// generated: pet-model-base.mjs / pet-model-base.d.ts
+// generated: pet-model-base.mjs / pet-model-base.d.mts
 import { BaseModel, type BaseModelConfig } from "@example/electrodb-base";
-import { Pet } from "./index.js";
+import { Pet } from "./index.mjs";
 
 export class PetModelBase extends BaseModel<typeof Pet> {
 	constructor(config: BaseModelConfig) {
@@ -299,7 +299,7 @@ export class PetModelBase extends BaseModel<typeof Pet> {
 Consumers import exactly the entities they need, directly by subpath:
 
 ```ts
-import { PetModelBase } from "@mycorp/ddb-entities/pet-model-base.js";
+import { PetModelBase } from "@mycorp/ddb-entities/pet-model-base";
 ```
 
 Hand-written business logic lives in a subclass, added only when it's needed, and survives regeneration:
@@ -321,6 +321,17 @@ There is deliberately no `model-base.js` (or similar) aggregating all generated 
 - Node's `exports` field only allows the subpaths that were actually generated — there's no deep-import escape hatch to unused, ungenerated code.
 
 Leaving `model-base` unset keeps the emitter's output byte-identical to before this option existed — it is strictly opt-in.
+
+### The runtime base class contract
+
+The emitter only ever generates wiring — `extends <ClassName><typeof Entity>` plus a constructor that calls `super(entity, config)` — so your `class-name` must have exactly this shape:
+
+- Exactly one generic/type parameter, instantiated as `<typeof Entity>` (the ElectroDB schema).
+- A two-argument constructor `(schema, config)`, where `config`'s type is whatever `config-type` names.
+
+A base class with a different generic arity or constructor signature will fail to compile against the generated code with a confusing error, rather than a clear diagnostic from this emitter — adapt or wrap your base class to match this exact shape.
+
+Because the emitter attaches `model-base` output to every model carrying `@entity` state, this also includes derived/param models that re-apply `@entity` to a mutated clone (for example a `Create<Person>` helper that produces a `CreatePerson` entity for input validation). Such a model gets a `CreatePersonModelBase` alongside the "real" table entities' model bases, mirroring how it's already present in the plain schema bundle — worth being aware of if you don't intend those derived models to be instantiable as ElectroDB models in their own right.
 
 ### The safe-write contract
 

--- a/README.md
+++ b/README.md
@@ -269,8 +269,70 @@ zero-pad width the encoder uses; a scalar whose pattern allows a wider
 segment is rejected at compile time rather than silently mis-sorting once a
 segment overflows the pad.
 
+## Opt-in model base class emission (generation-gap pattern)
+
+By default, the emitter only produces the ElectroDB schema bundle (`index.mjs`/`.cjs`/`.d.ts`). Enable the `model-base` option to additionally emit **one generation-gap base class per `@entity`**, wiring it to a runtime base class you supply:
+
+```yaml
+options:
+  typespec-electrodb-emitter:
+    model-base:
+      module: "@example/electrodb-base"
+      class-name: "BaseModel"
+      config-type: "BaseModelConfig"
+```
+
+For every `@entity` model (e.g. `Pet`), the emitter generates a standalone module — `pet-model-base.mjs`/`.cjs`/`.d.ts` — that is **not** re-exported from a shared barrel:
+
+```ts
+// generated: pet-model-base.mjs / pet-model-base.d.ts
+import { BaseModel, type BaseModelConfig } from "@example/electrodb-base";
+import { Pet } from "./index.js";
+
+export class PetModelBase extends BaseModel<typeof Pet> {
+	constructor(config: BaseModelConfig) {
+		super(Pet, config);
+	}
+}
+```
+
+Consumers import exactly the entities they need, directly by subpath:
+
+```ts
+import { PetModelBase } from "@mycorp/ddb-entities/pet-model-base.js";
+```
+
+Hand-written business logic lives in a subclass, added only when it's needed, and survives regeneration:
+
+```ts
+export class PetModel extends PetModelBase {
+	adopt(petId: string) {
+		/* business logic */
+	}
+}
+```
+
+### Why there's no barrel export
+
+There is deliberately no `model-base.js` (or similar) aggregating all generated classes, and no wildcard `exports` entry in the generated `package.json`. Each entity gets its own file and its own explicit `exports["./<entity>-model-base"]` entry. This means:
+
+- Importing one entity's model base never pulls in another entity's code.
+- It never transitively loads your runtime base-class module unless you actually import a `*-model-base` file that needs it.
+- Node's `exports` field only allows the subpaths that were actually generated — there's no deep-import escape hatch to unused, ungenerated code.
+
+Leaving `model-base` unset keeps the emitter's output byte-identical to before this option existed — it is strictly opt-in.
+
+### The safe-write contract
+
+This feature exists to close a real race condition: DynamoDB GSI reads (and default primary-key reads) are eventually consistent, so reading an item back immediately after writing it can intermittently return stale or missing data. Your runtime base class (the `module`/`class-name` you configure) is expected to guarantee, for every write path it exposes:
+
+- `update` / `upsert` / `patch` execute with `{ response: "all_new" }` and return the full written item — never a follow-up read.
+- `create` / `put` return the item ElectroDB composes locally from the input — no round-trip read is needed or should be performed.
+- No write path reads an item back after writing it.
+
+**Known limitation — transactions:** ElectroDB's `Service.transaction.write().commit()` only supports `response: "all_old"`; DynamoDB's `TransactWriteItems` has no `ReturnValues` for new state, so `all_new` isn't possible there. Post-transaction reads carry the same race and aren't fixed by this pattern. If your runtime base later adds transaction helpers, prefer composing the result locally from the transaction inputs over reading it back.
+
 ## Documentation
 
-This extension itself is driven by TypeSpec type definitions, mostly pieced together by reading existing (REST) extensions and https://typespec.io/docs/extending-typespec/create-decorators/
 
 See [./tsp/main.tsp](/tsp/main.tsp) for the type definitions of the annotations. 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
 			"devDependencies": {
 				"@babel/types": "^7.27.6",
 				"@biomejs/biome": "^2.3.8",
+				"@example/electrodb-base": "file:test/fixtures/electrodb-base-stub",
 				"@types/babel__generator": "^7.27.0",
 				"@types/node": "latest",
 				"@typescript-eslint/eslint-plugin": "^8.15.0",
@@ -1753,6 +1754,10 @@
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			}
+		},
+		"node_modules/@example/electrodb-base": {
+			"resolved": "test/fixtures/electrodb-base-stub",
+			"link": true
 		},
 		"node_modules/@humanfs/core": {
 			"version": "0.19.1",
@@ -10104,6 +10109,11 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"test/fixtures/electrodb-base-stub": {
+			"name": "@example/electrodb-base",
+			"version": "0.0.0",
+			"dev": true
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 	"devDependencies": {
 		"@babel/types": "^7.27.6",
 		"@biomejs/biome": "^2.3.8",
+		"@example/electrodb-base": "file:test/fixtures/electrodb-base-stub",
 		"@types/babel__generator": "^7.27.0",
 		"@types/node": "latest",
 		"@typescript-eslint/eslint-plugin": "^8.15.0",
@@ -44,10 +45,11 @@
 		"pretest": "npm run build",
 		"fix": "biome check --write",
 		"lint": "biome check",
-		"test": "npm run test:biome && npm run test:emit && npm run test:types && npm run test:unit",
+		"test": "npm run test:biome && npm run test:emit && npm run test:emit:model-base && npm run test:types && npm run test:unit",
 		"prepublishOnly": "npm run build",
 		"test:biome": "biome check src",
 		"test:emit": "tsp compile test/main.tsp --config test/tspconfig.yaml",
+		"test:emit:model-base": "tsp compile test/main.tsp --config test/tspconfig.model-base.yaml",
 		"test:unit": "node --import tsx --test test/**.test.ts",
 		"test:types": "tsc -p tsconfig.test.json"
 	},

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
 		"prepublishOnly": "npm run build",
 		"test:biome": "biome check src",
 		"test:emit": "tsp compile test/main.tsp --config test/tspconfig.yaml",
-		"test:emit:model-base": "tsp compile test/main.tsp --config test/tspconfig.model-base.yaml",
+		"test:emit:model-base": "rm -rf build/entities-model-base && tsp compile test/main.tsp --config test/tspconfig.model-base.yaml",
 		"test:unit": "node --import tsx --test test/**.test.ts",
 		"test:types": "tsc -p tsconfig.test.json"
 	},

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -26,8 +26,20 @@ import {
 import type { Attribute, CustomAttribute, Schema } from "electrodb";
 import * as ts from "typescript";
 
-import { StateKeys } from "./lib.js";
+import { type ModelBaseOptions, StateKeys } from "./lib.js";
 import { RawCode, stringifyObject } from "./stringify.js";
+
+/**
+ * Converts a PascalCase (or camelCase) entity name into a kebab-case base
+ * name suitable for a generated file name / package export subpath, e.g.
+ * "Person" -> "person", "HTTPHeader" -> "http-header", "Person2" -> "person2".
+ */
+function toKebabCase(name: string): string {
+	return name
+		.replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+		.replace(/([A-Z]+)([A-Z][a-z])/g, "$1-$2")
+		.toLowerCase();
+}
 
 /**
  * Extracts a primitive default value from a TypeSpec Value.
@@ -744,6 +756,114 @@ function isModel(type: Type): asserts type is Model {
 	assert(type.kind === "Model", "Type must be a model");
 }
 
+/**
+ * Builds the TypeScript source for a single entity's generation-gap model
+ * base class. This is deliberately emitted as one standalone module per
+ * entity (not a shared barrel) so a consumer that only needs a subset of
+ * entities' model bases never pulls in the others, or their runtime base
+ * class dependency, transitively.
+ */
+function buildModelBaseSource(
+	entityName: string,
+	options: ModelBaseOptions,
+	schemaSpecifier: string,
+): string {
+	const {
+		module,
+		"class-name": className,
+		"config-type": configType,
+	} = options;
+
+	return [
+		`import { ${className}, type ${configType} } from "${module}";`,
+		`import { ${entityName} } from "${schemaSpecifier}";`,
+		"",
+		`export class ${entityName}ModelBase extends ${className}<typeof ${entityName}> {`,
+		`\tconstructor(config: ${configType}) {`,
+		`\t\tsuper(${entityName}, config);`,
+		"\t}",
+		"}",
+		"",
+	].join("\n");
+}
+
+/**
+ * Emits the per-entity model base files (opt-in via the "model-base"
+ * emitter option). Returns the package.json `exports` entries for the
+ * emitted files, one per entity, so consumers can import exactly the
+ * entities they need without a barrel re-exporting everything.
+ */
+async function emitModelBaseFiles(
+	context: EmitContext,
+	entityNames: string[],
+): Promise<Record<string, unknown>> {
+	const options = context.options["model-base"];
+	if (!options) return {};
+
+	const exportsEntries: Record<string, unknown> = {};
+
+	for (const entityName of entityNames) {
+		const kebabName = toKebabCase(entityName);
+		const baseName = `${kebabName}-model-base`;
+
+		// The main schema bundle has no plain "index.js" file (only
+		// index.mjs/index.cjs), so the ESM and CJS variants of this file
+		// must each import the schema from the sibling file that actually
+		// exists for their module system.
+		const esmSource = buildModelBaseSource(entityName, options, "./index.mjs");
+		const cjsSource = buildModelBaseSource(entityName, options, "./index.cjs");
+
+		const esmDeclarations = await ts.transpileDeclaration(esmSource, {});
+		const cjsDeclarations = await ts.transpileDeclaration(cjsSource, {});
+		const esm = ts.transpileModule(esmSource, {
+			compilerOptions: {
+				module: ts.ModuleKind.ESNext,
+				target: ts.ScriptTarget.ES2022,
+			},
+		});
+		const cjs = ts.transpileModule(cjsSource, {
+			compilerOptions: {
+				module: ts.ModuleKind.CommonJS,
+				target: ts.ScriptTarget.ES2022,
+			},
+		});
+
+		await emitFile(context.program, {
+			path: resolvePath(context.emitterOutputDir, `${baseName}.d.ts`),
+			content: esmDeclarations.outputText,
+		});
+		await emitFile(context.program, {
+			path: resolvePath(context.emitterOutputDir, `${baseName}.d.mts`),
+			content: esmDeclarations.outputText,
+		});
+		await emitFile(context.program, {
+			path: resolvePath(context.emitterOutputDir, `${baseName}.d.cts`),
+			content: cjsDeclarations.outputText,
+		});
+		await emitFile(context.program, {
+			path: resolvePath(context.emitterOutputDir, `${baseName}.mjs`),
+			content: esm.outputText,
+		});
+		await emitFile(context.program, {
+			path: resolvePath(context.emitterOutputDir, `${baseName}.cjs`),
+			content: cjs.outputText,
+		});
+
+		exportsEntries[`./${baseName}`] = {
+			import: {
+				types: `./${baseName}.d.mts`,
+				default: `./${baseName}.mjs`,
+			},
+			require: {
+				types: `./${baseName}.d.cts`,
+				default: `./${baseName}.cjs`,
+			},
+		};
+	}
+
+	return exportsEntries;
+}
+
 export async function $onEmit(context: EmitContext) {
 	const packageName = context.options["package-name"];
 	const packageVersion = context.options["package-version"];
@@ -841,6 +961,11 @@ export async function $onEmit(context: EmitContext) {
 		content: cjs.outputText,
 	});
 
+	const modelBaseExports = await emitModelBaseFiles(
+		context,
+		Object.keys(entities),
+	);
+
 	await emitFile(context.program, {
 		path: resolvePath(context.emitterOutputDir, "package.json"),
 		content: JSON.stringify(
@@ -863,6 +988,7 @@ export async function $onEmit(context: EmitContext) {
 							default: "./index.cjs",
 						},
 					},
+					...modelBaseExports,
 				},
 			},
 			null,

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -26,7 +26,7 @@ import {
 import type { Attribute, CustomAttribute, Schema } from "electrodb";
 import * as ts from "typescript";
 
-import { type ModelBaseOptions, StateKeys } from "./lib.js";
+import { type ModelBaseOptions, reportDiagnostic, StateKeys } from "./lib.js";
 import { RawCode, stringifyObject } from "./stringify.js";
 
 /**
@@ -34,7 +34,7 @@ import { RawCode, stringifyObject } from "./stringify.js";
  * name suitable for a generated file name / package export subpath, e.g.
  * "Person" -> "person", "HTTPHeader" -> "http-header", "Person2" -> "person2".
  */
-function toKebabCase(name: string): string {
+export function toKebabCase(name: string): string {
 	return name
 		.replace(/([a-z0-9])([A-Z])/g, "$1-$2")
 		.replace(/([A-Z]+)([A-Z][a-z])/g, "$1-$2")
@@ -792,19 +792,47 @@ function buildModelBaseSource(
  * emitter option). Returns the package.json `exports` entries for the
  * emitted files, one per entity, so consumers can import exactly the
  * entities they need without a barrel re-exporting everything.
+ *
+ * Entity names are user-controlled and only compared after kebab-casing,
+ * so two distinct model names that collide once kebab-cased (e.g. `APIKey`
+ * and `ApiKey` both become `api-key`) would otherwise silently overwrite
+ * each other's generated files and collapse into a single `exports` entry.
+ * Such collisions are reported as a compile error instead, and no files
+ * are emitted for the colliding group.
  */
 async function emitModelBaseFiles(
 	context: EmitContext,
-	entityNames: string[],
+	models: Model[],
 ): Promise<Record<string, unknown>> {
 	const options = context.options["model-base"];
 	if (!options) return {};
 
 	const exportsEntries: Record<string, unknown> = {};
 
-	for (const entityName of entityNames) {
-		const kebabName = toKebabCase(entityName);
+	const groupsByKebabName = new Map<string, Model[]>();
+	for (const model of models) {
+		const kebabName = toKebabCase(model.name);
+		const group = groupsByKebabName.get(kebabName) ?? [];
+		group.push(model);
+		groupsByKebabName.set(kebabName, group);
+	}
+
+	for (const [kebabName, group] of groupsByKebabName) {
 		const baseName = `${kebabName}-model-base`;
+
+		if (group.length > 1) {
+			reportDiagnostic(context.program, {
+				code: "model-base-name-collision",
+				target: group[0],
+				format: {
+					names: group.map((model) => model.name).join(", "),
+					baseName,
+				},
+			});
+			continue;
+		}
+
+		const entityName = group[0].name;
 
 		// The main schema bundle has no plain "index.js" file (only
 		// index.mjs/index.cjs), so the ESM and CJS variants of this file
@@ -828,10 +856,12 @@ async function emitModelBaseFiles(
 			},
 		});
 
-		await emitFile(context.program, {
-			path: resolvePath(context.emitterOutputDir, `${baseName}.d.ts`),
-			content: esmDeclarations.outputText,
-		});
+		// Only .d.mts/.d.cts are emitted: the generated `exports` map's
+		// subpath type resolution reads `import.types`/`require.types`,
+		// which point at those files. A plain `.d.ts` would never be
+		// referenced by anything (the root bundle's `.d.ts` exists for its
+		// legacy top-level `types` field, which model-base subpaths don't
+		// have), so it isn't emitted here.
 		await emitFile(context.program, {
 			path: resolvePath(context.emitterOutputDir, `${baseName}.d.mts`),
 			content: esmDeclarations.outputText,
@@ -870,6 +900,7 @@ export async function $onEmit(context: EmitContext) {
 
 	// biome-ignore lint/suspicious/noExplicitAny: <ElecroDB Schema>
 	const entities: Record<string, Schema<any, any, any>> = {};
+	const entityModels: Model[] = [];
 
 	for (const [model, props] of context.program
 		.stateMap(StateKeys.electroEntity)
@@ -887,6 +918,7 @@ export async function $onEmit(context: EmitContext) {
 				version: props.version ?? "1",
 			},
 		};
+		entityModels.push(model);
 	}
 
 	const entityDefinitions = Object.entries(entities)
@@ -961,10 +993,7 @@ export async function $onEmit(context: EmitContext) {
 		content: cjs.outputText,
 	});
 
-	const modelBaseExports = await emitModelBaseFiles(
-		context,
-		Object.keys(entities),
-	);
+	const modelBaseExports = await emitModelBaseFiles(context, entityModels);
 
 	await emitFile(context.program, {
 		path: resolvePath(context.emitterOutputDir, "package.json"),

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,8 +1,35 @@
 import { createTypeSpecLibrary, type JSONSchemaType } from "@typespec/compiler";
+
+export interface ModelBaseOptions {
+	module: string;
+	"class-name": string;
+	"config-type": string;
+}
+
 export interface EmitterOptions {
 	"package-name": string;
 	"package-version": string;
+	"model-base"?: ModelBaseOptions;
 }
+
+const ModelBaseOptionsSchema: JSONSchemaType<ModelBaseOptions> = {
+	type: "object",
+	required: ["module", "class-name", "config-type"],
+	properties: {
+		module: {
+			nullable: false,
+			type: "string",
+		},
+		"class-name": {
+			nullable: false,
+			type: "string",
+		},
+		"config-type": {
+			nullable: false,
+			type: "string",
+		},
+	},
+};
 
 const EmitterOptionsSchema: JSONSchemaType<EmitterOptions> = {
 	type: "object",
@@ -17,6 +44,11 @@ const EmitterOptionsSchema: JSONSchemaType<EmitterOptions> = {
 			default: "1.0.0",
 			nullable: false,
 			type: "string",
+		},
+		"model-base": {
+			...ModelBaseOptionsSchema,
+			nullable: true,
+			default: undefined,
 		},
 	},
 };

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,4 +1,8 @@
-import { createTypeSpecLibrary, type JSONSchemaType } from "@typespec/compiler";
+import {
+	createTypeSpecLibrary,
+	type JSONSchemaType,
+	paramMessage,
+} from "@typespec/compiler";
 
 export interface ModelBaseOptions {
 	module: string;
@@ -63,6 +67,14 @@ export const $lib = createTypeSpecLibrary({
 			messages: {
 				default:
 					"@semanticVersion can only be applied to a property typed as (or extending) a string matching the semantic version pattern, e.g. the `SemanticVersion` scalar exported by this library.",
+			},
+		},
+		"model-base-name-collision": {
+			severity: "error",
+			description:
+				"Two or more @entity models produce the same kebab-case model-base file/export name.",
+			messages: {
+				default: paramMessage`Entities ${"names"} all map to the same model-base name '${"baseName"}' (e.g. 'APIKey' and 'ApiKey' both kebab-case to 'api-key'). Rename one of the entities so their model-base output doesn't collide.`,
 			},
 		},
 	},

--- a/test/fixtures/electrodb-base-stub/index.cjs
+++ b/test/fixtures/electrodb-base-stub/index.cjs
@@ -1,0 +1,11 @@
+/**
+ * CommonJS counterpart of index.mjs — see that file for the rationale.
+ */
+class BaseModel {
+	constructor(schema, config) {
+		this.schema = schema;
+		this.config = config;
+	}
+}
+
+module.exports = { BaseModel };

--- a/test/fixtures/electrodb-base-stub/index.d.ts
+++ b/test/fixtures/electrodb-base-stub/index.d.ts
@@ -1,0 +1,10 @@
+export declare class BaseModel<S = unknown> {
+	schema: S;
+	// biome-ignore lint/suspicious/noExplicitAny: <test stub, shape is intentionally open>
+	config: any;
+	// biome-ignore lint/suspicious/noExplicitAny: <test stub, shape is intentionally open>
+	constructor(schema: S, config: any);
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: <test stub, shape is intentionally open>
+export type BaseModelConfig = any;

--- a/test/fixtures/electrodb-base-stub/index.mjs
+++ b/test/fixtures/electrodb-base-stub/index.mjs
@@ -1,0 +1,13 @@
+/**
+ * Minimal stand-in for a consumer's runtime base class. Real implementations
+ * are expected to expose safe write helpers (update/upsert/patch with
+ * `{ response: "all_new" }`, create/put returning the local echo) — this stub
+ * only needs to prove that generated *-model-base files load and wire up
+ * `super(schema, config)` correctly.
+ */
+export class BaseModel {
+	constructor(schema, config) {
+		this.schema = schema;
+		this.config = config;
+	}
+}

--- a/test/fixtures/electrodb-base-stub/package.json
+++ b/test/fixtures/electrodb-base-stub/package.json
@@ -1,0 +1,17 @@
+{
+	"name": "@example/electrodb-base",
+	"version": "0.0.0",
+	"private": true,
+	"description": "Minimal stub runtime base class used to smoke-test generated *-model-base files actually load and wire up correctly.",
+	"type": "module",
+	"main": "./index.cjs",
+	"module": "./index.mjs",
+	"types": "./index.d.ts",
+	"exports": {
+		".": {
+			"types": "./index.d.ts",
+			"import": "./index.mjs",
+			"require": "./index.cjs"
+		}
+	}
+}

--- a/test/fixtures/model-base-name-collision.tsp
+++ b/test/fixtures/model-base-name-collision.tsp
@@ -1,0 +1,15 @@
+import "typespec-electrodb-emitter";
+
+// Two distinct entity names that kebab-case to the same model-base base
+// name ("api-key") once emitted. With the "model-base" option enabled,
+// this must be a compile-time diagnostic rather than a silent last-write-
+// wins file collision.
+@entity("apiKeyA", "org")
+model APIKey {
+    pk: string;
+}
+
+@entity("apiKeyB", "org")
+model ApiKey {
+    pk: string;
+}

--- a/test/model-base-runtime.test.ts
+++ b/test/model-base-runtime.test.ts
@@ -2,8 +2,8 @@ import assert from "node:assert/strict";
 import { createRequire } from "node:module";
 import { suite, test } from "node:test";
 import { BaseModel } from "@example/electrodb-base";
-
 import * as generatedEntities from "../build/entities-model-base/index.mjs";
+import { toKebabCase } from "../src/emitter.js";
 
 const require = createRequire(import.meta.url);
 
@@ -15,24 +15,17 @@ const require = createRequire(import.meta.url);
  *
  * The entity list is derived from the actual generated bundle rather than
  * hardcoded, so this suite can't silently drift out of sync with the
- * fixture (see test/main.tsp for the source of truth).
+ * fixture (see test/main.tsp for the source of truth). Uses the emitter's
+ * own toKebabCase, rather than a re-implementation, so the test can't
+ * drift from the actual name mapping the emitter applies.
  */
-function toKebabCase(name: string): string {
-	return name
-		.replace(/([a-z0-9])([A-Z])/g, "$1-$2")
-		.replace(/([A-Z]+)([A-Z][a-z])/g, "$1-$2")
-		.toLowerCase();
-}
-
 const entityNames = Object.keys(generatedEntities).sort();
 
 suite("Generated ModelBase classes (ESM runtime)", () => {
 	for (const entityName of entityNames) {
 		const kebabName = toKebabCase(entityName);
 		const className = `${entityName}ModelBase`;
-		const schema = (generatedEntities as Record<string, unknown>)[
-			entityName
-		];
+		const schema = (generatedEntities as Record<string, unknown>)[entityName];
 
 		test(`${className} extends the configured runtime base class`, async () => {
 			const mod = await import(
@@ -61,9 +54,10 @@ suite("Generated ModelBase classes (ESM runtime)", () => {
 
 suite("Generated ModelBase classes (CJS runtime)", () => {
 	const { BaseModel: CjsBaseModel } = require("@example/electrodb-base");
-	const cjsEntities: Record<string, unknown> = require(
-		"../build/entities-model-base/index.cjs",
-	);
+	const cjsEntities: Record<
+		string,
+		unknown
+	> = require("../build/entities-model-base/index.cjs");
 
 	for (const entityName of entityNames) {
 		const kebabName = toKebabCase(entityName);

--- a/test/model-base-runtime.test.ts
+++ b/test/model-base-runtime.test.ts
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import { suite, test } from "node:test";
+import { BaseModel } from "@example/electrodb-base";
+
+import * as generatedEntities from "../build/entities-model-base/index.mjs";
+
+const require = createRequire(import.meta.url);
+
+/**
+ * These are genuine runtime smoke tests: generated *-model-base.mjs/.cjs
+ * modules are actually imported/required and executed (not just inspected
+ * as source text), matching the convention already used in
+ * entities.test.ts / electrodb.test.ts for the core schema bundle.
+ *
+ * The entity list is derived from the actual generated bundle rather than
+ * hardcoded, so this suite can't silently drift out of sync with the
+ * fixture (see test/main.tsp for the source of truth).
+ */
+function toKebabCase(name: string): string {
+	return name
+		.replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+		.replace(/([A-Z]+)([A-Z][a-z])/g, "$1-$2")
+		.toLowerCase();
+}
+
+const entityNames = Object.keys(generatedEntities).sort();
+
+suite("Generated ModelBase classes (ESM runtime)", () => {
+	for (const entityName of entityNames) {
+		const kebabName = toKebabCase(entityName);
+		const className = `${entityName}ModelBase`;
+		const schema = (generatedEntities as Record<string, unknown>)[
+			entityName
+		];
+
+		test(`${className} extends the configured runtime base class`, async () => {
+			const mod = await import(
+				`../build/entities-model-base/${kebabName}-model-base.mjs`
+			);
+			const ModelBaseClass = mod[className];
+
+			assert.equal(typeof ModelBaseClass, "function");
+			assert.equal(ModelBaseClass.prototype instanceof BaseModel, true);
+		});
+
+		test(`${className} forwards its own schema and the config to super()`, async () => {
+			const mod = await import(
+				`../build/entities-model-base/${kebabName}-model-base.mjs`
+			);
+			const ModelBaseClass = mod[className];
+			const config = { table: "test-table", client: {} };
+			const instance = new ModelBaseClass(config);
+
+			assert.equal(instance instanceof BaseModel, true);
+			assert.equal(instance.schema, schema);
+			assert.equal(instance.config, config);
+		});
+	}
+});
+
+suite("Generated ModelBase classes (CJS runtime)", () => {
+	const { BaseModel: CjsBaseModel } = require("@example/electrodb-base");
+	const cjsEntities: Record<string, unknown> = require(
+		"../build/entities-model-base/index.cjs",
+	);
+
+	for (const entityName of entityNames) {
+		const kebabName = toKebabCase(entityName);
+		const className = `${entityName}ModelBase`;
+		const schema = cjsEntities[entityName];
+
+		test(`${className} (cjs) extends the configured runtime base class`, () => {
+			const mod = require(
+				`../build/entities-model-base/${kebabName}-model-base.cjs`,
+			);
+			const ModelBaseClass = mod[className];
+
+			assert.equal(typeof ModelBaseClass, "function");
+			assert.equal(ModelBaseClass.prototype instanceof CjsBaseModel, true);
+		});
+
+		test(`${className} (cjs) forwards its own schema and the config to super()`, () => {
+			const mod = require(
+				`../build/entities-model-base/${kebabName}-model-base.cjs`,
+			);
+			const ModelBaseClass = mod[className];
+			const config = { table: "test-table", client: {} };
+			const instance = new ModelBaseClass(config);
+
+			assert.equal(instance instanceof CjsBaseModel, true);
+			assert.equal(instance.schema, schema);
+			assert.equal(instance.config, config);
+		});
+	}
+});

--- a/test/model-base.test.ts
+++ b/test/model-base.test.ts
@@ -1,27 +1,35 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import { existsSync, readdirSync, readFileSync } from "node:fs";
-import { resolve } from "node:path";
 import { suite, test } from "node:test";
-
+import { fileURLToPath } from "node:url";
 import * as generatedEntities from "../build/entities-model-base/index.mjs";
+import { toKebabCase } from "../src/emitter.js";
 
-const defaultBuildDir = resolve(import.meta.dirname, "../build/entities");
-const modelBaseBuildDir = resolve(
-	import.meta.dirname,
-	"../build/entities-model-base",
+const tspBin = new URL("../node_modules/.bin/tsp", import.meta.url).pathname;
+
+const defaultBuildDir = fileURLToPath(
+	new URL("../build/entities", import.meta.url),
 );
+const modelBaseBuildDir = fileURLToPath(
+	new URL("../build/entities-model-base", import.meta.url),
+);
+
+function modelBasePath(...segments: string[]): string {
+	return fileURLToPath(
+		new URL(
+			`../build/entities-model-base/${segments.join("/")}`,
+			import.meta.url,
+		),
+	);
+}
 
 // Derived from the actual generated bundle (rather than hardcoded) so this
 // suite can't silently drift out of sync with the fixture's entity list.
+// Uses the emitter's own toKebabCase, rather than a re-implementation, so
+// the test can't drift from the actual name mapping the emitter applies.
 const entityNames = Object.keys(generatedEntities).sort();
-const kebabNames = entityNames.map(toKebabCaseForTest);
-
-function toKebabCaseForTest(name: string): string {
-	return name
-		.replace(/([a-z0-9])([A-Z])/g, "$1-$2")
-		.replace(/([A-Z]+)([A-Z][a-z])/g, "$1-$2")
-		.toLowerCase();
-}
+const kebabNames = entityNames.map(toKebabCase);
 
 suite("model-base option unset (default build)", () => {
 	test("no model-base files are emitted next to the default entity bundle", () => {
@@ -32,7 +40,7 @@ suite("model-base option unset (default build)", () => {
 
 	test("package.json exports only the '.' entry", () => {
 		const pkg = JSON.parse(
-			readFileSync(resolve(defaultBuildDir, "package.json"), "utf-8"),
+			readFileSync(`${defaultBuildDir}/package.json`, "utf-8"),
 		);
 		assert.deepEqual(Object.keys(pkg.exports), ["."]);
 	});
@@ -49,14 +57,20 @@ suite("model-base option set", () => {
 		);
 
 		for (const kebabName of kebabNames) {
-			for (const ext of [".mjs", ".cjs", ".d.ts", ".d.mts", ".d.cts"]) {
+			// Only .mjs/.cjs/.d.mts/.d.cts are emitted; a plain .d.ts would be
+			// dead output since the exports map's subpath type resolution only
+			// reads import.types/require.types (the .d.mts/.d.cts variants).
+			for (const ext of [".mjs", ".cjs", ".d.mts", ".d.cts"]) {
 				assert.ok(
-					existsSync(
-						resolve(modelBaseBuildDir, `${kebabName}-model-base${ext}`),
-					),
+					existsSync(modelBasePath(`${kebabName}-model-base${ext}`)),
 					`expected ${kebabName}-model-base${ext} to exist`,
 				);
 			}
+			assert.equal(
+				existsSync(modelBasePath(`${kebabName}-model-base.d.ts`)),
+				false,
+				`${kebabName}-model-base.d.ts should not be emitted (dead output)`,
+			);
 		}
 	});
 
@@ -65,7 +79,7 @@ suite("model-base option set", () => {
 	)) {
 		test(`${entityName}ModelBase wires the correct base class, schema and config type`, () => {
 			const source = readFileSync(
-				resolve(modelBaseBuildDir, `${kebabName}-model-base.d.ts`),
+				modelBasePath(`${kebabName}-model-base.d.mts`),
 				"utf-8",
 			);
 
@@ -83,15 +97,12 @@ suite("model-base option set", () => {
 					`export declare class ${entityName}ModelBase extends BaseModel<typeof ${entityName}>`,
 				),
 			);
-			assert.match(
-				source,
-				/constructor\(config: BaseModelConfig\);/,
-			);
+			assert.match(source, /constructor\(config: BaseModelConfig\);/);
 		});
 
 		test(`${entityName}ModelBase file imports no other entity's schema`, () => {
 			const source = readFileSync(
-				resolve(modelBaseBuildDir, `${kebabName}-model-base.mjs`),
+				modelBasePath(`${kebabName}-model-base.mjs`),
 				"utf-8",
 			);
 
@@ -112,7 +123,7 @@ suite("model-base option set", () => {
 
 	test("package.json has an explicit exports entry per entity, no wildcard/barrel", () => {
 		const pkg = JSON.parse(
-			readFileSync(resolve(modelBaseBuildDir, "package.json"), "utf-8"),
+			readFileSync(modelBasePath("package.json"), "utf-8"),
 		);
 		const exportKeys = Object.keys(pkg.exports).sort();
 		const expectedKeys = [
@@ -139,5 +150,39 @@ suite("model-base option set", () => {
 				},
 			});
 		}
+	});
+});
+
+suite("model-base kebab-case name collisions", () => {
+	test("two entity names that kebab-case to the same base name is a compile-time error, not a silent overwrite", () => {
+		let combinedOutput = "";
+
+		assert.throws(
+			() =>
+				execFileSync(
+					tspBin,
+					[
+						"compile",
+						"test/fixtures/model-base-name-collision.tsp",
+						"--config",
+						"test/tspconfig.model-base-collision.yaml",
+					],
+					{ stdio: "pipe" },
+				),
+			(error: unknown) => {
+				assert.ok(error instanceof Error);
+				const { stdout, stderr } = error as {
+					stdout?: Buffer;
+					stderr?: Buffer;
+				};
+				combinedOutput = `${String(stdout ?? "")}${String(stderr ?? "")}`;
+				return true;
+			},
+		);
+
+		assert.match(combinedOutput, /myLibrary\/model-base-name-collision/);
+		assert.match(combinedOutput, /api-key/);
+		assert.match(combinedOutput, /APIKey/);
+		assert.match(combinedOutput, /ApiKey/);
 	});
 });

--- a/test/model-base.test.ts
+++ b/test/model-base.test.ts
@@ -1,0 +1,143 @@
+import assert from "node:assert/strict";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { suite, test } from "node:test";
+
+import * as generatedEntities from "../build/entities-model-base/index.mjs";
+
+const defaultBuildDir = resolve(import.meta.dirname, "../build/entities");
+const modelBaseBuildDir = resolve(
+	import.meta.dirname,
+	"../build/entities-model-base",
+);
+
+// Derived from the actual generated bundle (rather than hardcoded) so this
+// suite can't silently drift out of sync with the fixture's entity list.
+const entityNames = Object.keys(generatedEntities).sort();
+const kebabNames = entityNames.map(toKebabCaseForTest);
+
+function toKebabCaseForTest(name: string): string {
+	return name
+		.replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+		.replace(/([A-Z]+)([A-Z][a-z])/g, "$1-$2")
+		.toLowerCase();
+}
+
+suite("model-base option unset (default build)", () => {
+	test("no model-base files are emitted next to the default entity bundle", () => {
+		const files = readdirSync(defaultBuildDir);
+		const modelBaseFiles = files.filter((f) => f.includes("model-base"));
+		assert.deepEqual(modelBaseFiles, []);
+	});
+
+	test("package.json exports only the '.' entry", () => {
+		const pkg = JSON.parse(
+			readFileSync(resolve(defaultBuildDir, "package.json"), "utf-8"),
+		);
+		assert.deepEqual(Object.keys(pkg.exports), ["."]);
+	});
+});
+
+suite("model-base option set", () => {
+	test("one file-set per entity is emitted, no shared barrel", () => {
+		const files = readdirSync(modelBaseBuildDir);
+
+		// no aggregating "model-base.*" barrel file
+		assert.equal(
+			files.some((f) => /^model-base\./.test(f)),
+			false,
+		);
+
+		for (const kebabName of kebabNames) {
+			for (const ext of [".mjs", ".cjs", ".d.ts", ".d.mts", ".d.cts"]) {
+				assert.ok(
+					existsSync(
+						resolve(modelBaseBuildDir, `${kebabName}-model-base${ext}`),
+					),
+					`expected ${kebabName}-model-base${ext} to exist`,
+				);
+			}
+		}
+	});
+
+	for (const [entityName, kebabName] of entityNames.map(
+		(name, i) => [name, kebabNames[i]] as const,
+	)) {
+		test(`${entityName}ModelBase wires the correct base class, schema and config type`, () => {
+			const source = readFileSync(
+				resolve(modelBaseBuildDir, `${kebabName}-model-base.d.ts`),
+				"utf-8",
+			);
+
+			assert.match(
+				source,
+				/import \{ BaseModel, type BaseModelConfig \} from "@example\/electrodb-base";/,
+			);
+			assert.match(
+				source,
+				new RegExp(`import \\{ ${entityName} \\} from "\\./index\\.mjs";`),
+			);
+			assert.match(
+				source,
+				new RegExp(
+					`export declare class ${entityName}ModelBase extends BaseModel<typeof ${entityName}>`,
+				),
+			);
+			assert.match(
+				source,
+				/constructor\(config: BaseModelConfig\);/,
+			);
+		});
+
+		test(`${entityName}ModelBase file imports no other entity's schema`, () => {
+			const source = readFileSync(
+				resolve(modelBaseBuildDir, `${kebabName}-model-base.mjs`),
+				"utf-8",
+			);
+
+			const otherNames = entityNames.filter((name) => name !== entityName);
+			for (const otherName of otherNames) {
+				// Word-boundary aware: substring checks would false-positive on
+				// names that legitimately contain another (e.g. "CreatePerson"
+				// contains "Person"), so assert on the actual named import
+				// instead of a bare substring match.
+				assert.doesNotMatch(
+					source,
+					new RegExp(`\\{[^}]*\\b${otherName}\\b[^}]*\\}\\s*from`),
+					`${kebabName}-model-base.mjs should not import ${otherName}`,
+				);
+			}
+		});
+	}
+
+	test("package.json has an explicit exports entry per entity, no wildcard/barrel", () => {
+		const pkg = JSON.parse(
+			readFileSync(resolve(modelBaseBuildDir, "package.json"), "utf-8"),
+		);
+		const exportKeys = Object.keys(pkg.exports).sort();
+		const expectedKeys = [
+			".",
+			...kebabNames.map((name) => `./${name}-model-base`),
+		].sort();
+
+		assert.deepEqual(exportKeys, expectedKeys);
+		assert.equal(
+			Object.keys(pkg.exports).some((key) => key.includes("*")),
+			false,
+		);
+
+		for (const kebabName of kebabNames) {
+			const entry = pkg.exports[`./${kebabName}-model-base`];
+			assert.deepEqual(entry, {
+				import: {
+					types: `./${kebabName}-model-base.d.mts`,
+					default: `./${kebabName}-model-base.mjs`,
+				},
+				require: {
+					types: `./${kebabName}-model-base.d.cts`,
+					default: `./${kebabName}-model-base.cjs`,
+				},
+			});
+		}
+	});
+});

--- a/test/tspconfig.model-base-collision.yaml
+++ b/test/tspconfig.model-base-collision.yaml
@@ -1,0 +1,11 @@
+emit:
+  - "typespec-electrodb-emitter"
+options:
+  "typespec-electrodb-emitter":
+    package-name: "@mycorp/ddb-entities-collision-fixture"
+    package-version: "0.1.0"
+    emitter-output-dir: "{cwd}/build/entities-model-base-collision-fixture"
+    model-base:
+      module: "@example/electrodb-base"
+      class-name: "BaseModel"
+      config-type: "BaseModelConfig"

--- a/test/tspconfig.model-base.yaml
+++ b/test/tspconfig.model-base.yaml
@@ -1,0 +1,11 @@
+emit:
+  - "typespec-electrodb-emitter"
+options:
+  "typespec-electrodb-emitter":
+    package-name: "@mycorp/ddb-entities"
+    package-version: "0.1.0"
+    emitter-output-dir: "{cwd}/build/entities-model-base"
+    model-base:
+      module: "@example/electrodb-base"
+      class-name: "BaseModel"
+      config-type: "BaseModelConfig"


### PR DESCRIPTION
Closes #44.

## Summary

Adds an opt-in `model-base` emitter option. When configured, emits one standalone `<Entity>ModelBase` class per `@entity`, extending a consumer-supplied runtime base class and wiring `super(schema, config)`.

```yaml
options:
  typespec-electrodb-emitter:
    model-base:
      module: "@example/electrodb-base"
      class-name: "BaseModel"
      config-type: "BaseModelConfig"
```

## Design: no barrel exports

Per discussion on the issue, this is built so a consumer can pick and choose which entities' model bases to pull in:

- One file-set per entity (`<entity>-model-base.{mjs,cjs,d.ts,d.mts,d.cts}`) — no aggregating `model-base.js` re-exporting everything.
- One explicit `package.json` `exports["./<entity>-model-base"]` entry per emitted entity — no wildcard subpath.
- Each file only imports its own entity's schema (from the existing `index.mjs`/`.cjs` bundle) and the configured runtime base class — importing one entity's model base never pulls in another entity's code or the base-class dependency graph unless you actually import that file.
- Leaving `model-base` unset keeps output byte-identical to today — strictly opt-in.

## Safe-write contract

The emitter only generates wiring (`extends` + constructor). The actual safe-write behavior (`update`/`upsert`/`patch` → `response: "all_new"`, `create`/`put` returning the local echo, never reading back after a write) is documented in the README as the contract the consumer's runtime base class must implement — the emitter has no way to generate that behavior since it doesn't know the base class's method names.

## Testing

- `test/model-base.test.ts` — structural tests: file emission (all 5 extensions per entity), no shared barrel file, correct wiring content in `.d.ts`, no entity's file imports another entity's schema, and `package.json` exports map matches exactly (derived dynamically from the actual generated bundle, so it can't drift from the fixture).
- `test/model-base-runtime.test.ts` — genuine runtime smoke tests: a stub `@example/electrodb-base` package (`test/fixtures/electrodb-base-stub`, wired as a `file:` devDependency) is actually imported/required by the generated `*-model-base.mjs`/`.cjs` files, each class is instantiated, and `super(schema, config)` wiring is asserted at runtime for both ESM and CJS — matching the existing convention in `entities.test.ts`/`electrodb.test.ts` of executing real generated output rather than only inspecting source text. This caught (and led to fixing) a real bug where generated files referenced a non-existent `./index.js` instead of the actual `index.mjs`/`index.cjs`.
- `test/tspconfig.model-base.yaml` — new tspconfig variant compiling `test/main.tsp` with `model-base` enabled, wired into `npm test` via a new `test:emit:model-base` script.

148/148 tests passing (biome, `tsp compile` ×2 configs, `tsc` types, unit tests).