### PR TITLE
feat!: bind the model-base schema as a member, not a constructor argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,6 @@ options:
     model-base:
       module: "@example/electrodb-base"
       class-name: "BaseModel"
-      config-type: "BaseModelConfig"
 ```
 
 Each entity gets its own file (`pet-model-base.mjs` and friends) with its own
@@ -128,12 +127,31 @@ export class PetModel extends PetModelBase {
 }
 ```
 
-Your `class-name` must take one type parameter (instantiated as `<typeof Entity>`)
-and a two-argument constructor `(schema, config)`. The emitter generates only
-this wiring; the base class must provide the read-after-write safety it relies
-on (`update`/`upsert`/`patch` with `response: "all_new"`, no read-back after a
-write). ElectroDB transactions only support `all_old`, so post-transaction
-reads keep DynamoDB's eventual-consistency race.
+Your `class-name` must take one type parameter, instantiated as
+`<typeof Entity>`. Its constructor is yours: the generated class declares none,
+so it inherits whatever your base class takes.
+
+The schema arrives as a `protected readonly schema` member, which is set after
+`super()` returns. Your base class must therefore read it lazily rather than
+during construction:
+
+```ts
+export class BaseModel<S> {
+    protected readonly schema!: S;
+
+    constructor(private readonly client: DynamoDBClient, private readonly table: string) {}
+
+    protected get entity() {
+        return new Entity(this.schema, { client: this.client, table: this.table });
+    }
+}
+```
+
+The emitter generates only this wiring; the base class must provide the
+read-after-write safety it relies on (`update`/`upsert`/`patch` with
+`response: "all_new"`, no read-back after a write). ElectroDB transactions only
+support `all_old`, so post-transaction reads keep DynamoDB's
+eventual-consistency race.
 
 Leaving `model-base` unset keeps the output byte-identical to before the option
 existed.

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -762,26 +762,25 @@ function isModel(type: Type): asserts type is Model {
  * entity (not a shared barrel) so a consumer that only needs a subset of
  * entities' model bases never pulls in the others, or their runtime base
  * class dependency, transitively.
+ *
+ * The schema is bound as a member rather than passed to a constructor, so
+ * the runtime base class keeps whatever constructor it already has.
  */
 function buildModelBaseSource(
 	entityName: string,
 	options: ModelBaseOptions,
 	schemaSpecifier: string,
 ): string {
-	const {
-		module,
-		"class-name": className,
-		"config-type": configType,
-	} = options;
+	const { module, "class-name": className } = options;
 
 	return [
-		`import { ${className}, type ${configType} } from "${module}";`,
+		`import { ${className} } from "${module}";`,
 		`import { ${entityName} } from "${schemaSpecifier}";`,
 		"",
 		`export class ${entityName}ModelBase extends ${className}<typeof ${entityName}> {`,
-		`\tconstructor(config: ${configType}) {`,
-		`\t\tsuper(${entityName}, config);`,
-		"\t}",
+		// Annotated explicitly: declaration emit is syntactic, so an inferred
+		// initializer would widen to `any` in the .d.mts/.d.cts output.
+		`\tprotected readonly schema: typeof ${entityName} = ${entityName};`,
 		"}",
 		"",
 	].join("\n");

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -18,6 +18,7 @@ export interface EmitterOptions {
 const ModelBaseOptionsSchema: JSONSchemaType<ModelBaseOptions> = {
 	type: "object",
 	required: ["module", "class-name"],
+	additionalProperties: false,
 	properties: {
 		module: {
 			nullable: false,

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -7,7 +7,6 @@ import {
 export interface ModelBaseOptions {
 	module: string;
 	"class-name": string;
-	"config-type": string;
 }
 
 export interface EmitterOptions {
@@ -18,17 +17,13 @@ export interface EmitterOptions {
 
 const ModelBaseOptionsSchema: JSONSchemaType<ModelBaseOptions> = {
 	type: "object",
-	required: ["module", "class-name", "config-type"],
+	required: ["module", "class-name"],
 	properties: {
 		module: {
 			nullable: false,
 			type: "string",
 		},
 		"class-name": {
-			nullable: false,
-			type: "string",
-		},
-		"config-type": {
 			nullable: false,
 			type: "string",
 		},

--- a/test/fixtures/electrodb-base-stub/index.cjs
+++ b/test/fixtures/electrodb-base-stub/index.cjs
@@ -2,9 +2,18 @@
  * CommonJS counterpart of index.mjs — see that file for the rationale.
  */
 class BaseModel {
-	constructor(schema, config) {
-		this.schema = schema;
-		this.config = config;
+	constructor(client, table, salt) {
+		this.client = client;
+		this.table = table;
+		this.salt = salt;
+	}
+
+	get entity() {
+		return this.getEntity(this.schema);
+	}
+
+	getEntity(schema) {
+		return { schema, client: this.client, table: this.table, salt: this.salt };
 	}
 }
 

--- a/test/fixtures/electrodb-base-stub/index.d.ts
+++ b/test/fixtures/electrodb-base-stub/index.d.ts
@@ -1,10 +1,19 @@
-export declare class BaseModel<S = unknown> {
+export interface Entity<S> {
 	schema: S;
 	// biome-ignore lint/suspicious/noExplicitAny: <test stub, shape is intentionally open>
-	config: any;
-	// biome-ignore lint/suspicious/noExplicitAny: <test stub, shape is intentionally open>
-	constructor(schema: S, config: any);
+	client: any;
+	table: string;
+	salt: string;
 }
 
-// biome-ignore lint/suspicious/noExplicitAny: <test stub, shape is intentionally open>
-export type BaseModelConfig = any;
+export declare class BaseModel<S = unknown> {
+	protected readonly schema: S;
+	// biome-ignore lint/suspicious/noExplicitAny: <test stub, shape is intentionally open>
+	readonly client: any;
+	readonly table: string;
+	readonly salt: string;
+	// biome-ignore lint/suspicious/noExplicitAny: <test stub, shape is intentionally open>
+	constructor(client: any, table: string, salt: string);
+	protected get entity(): Entity<S>;
+	protected getEntity(schema: S): Entity<S>;
+}

--- a/test/fixtures/electrodb-base-stub/index.mjs
+++ b/test/fixtures/electrodb-base-stub/index.mjs
@@ -2,12 +2,28 @@
  * Minimal stand-in for a consumer's runtime base class. Real implementations
  * are expected to expose safe write helpers (update/upsert/patch with
  * `{ response: "all_new" }`, create/put returning the local echo) — this stub
- * only needs to prove that generated *-model-base files load and wire up
- * `super(schema, config)` correctly.
+ * only needs to prove that generated *-model-base files load and bind their
+ * own schema.
+ *
+ * The constructor arguments are deliberately arbitrary: the generated subclass
+ * declares no constructor, so whatever this one takes is what callers pass.
+ *
+ * `this.schema` is bound by the generated subclass as a field initializer,
+ * which runs only after `super()` returns, so it cannot be read during
+ * construction. The entity is built lazily for that reason.
  */
 export class BaseModel {
-	constructor(schema, config) {
-		this.schema = schema;
-		this.config = config;
+	constructor(client, table, salt) {
+		this.client = client;
+		this.table = table;
+		this.salt = salt;
+	}
+
+	get entity() {
+		return this.getEntity(this.schema);
+	}
+
+	getEntity(schema) {
+		return { schema, client: this.client, table: this.table, salt: this.salt };
 	}
 }

--- a/test/model-base-runtime.test.ts
+++ b/test/model-base-runtime.test.ts
@@ -13,6 +13,10 @@ const require = createRequire(import.meta.url);
  * as source text), matching the convention already used in
  * entities.test.ts / electrodb.test.ts for the core schema bundle.
  *
+ * The stub base class takes `(client, table, salt)` — arguments the emitter
+ * knows nothing about — so constructing a generated class through them is
+ * what proves the base's constructor is left alone.
+ *
  * The entity list is derived from the actual generated bundle rather than
  * hardcoded, so this suite can't silently drift out of sync with the
  * fixture (see test/main.tsp for the source of truth). Uses the emitter's
@@ -20,6 +24,10 @@ const require = createRequire(import.meta.url);
  * drift from the actual name mapping the emitter applies.
  */
 const entityNames = Object.keys(generatedEntities).sort();
+
+const client = { send: () => {} };
+const table = "test-table";
+const salt = "pepper";
 
 suite("Generated ModelBase classes (ESM runtime)", () => {
 	for (const entityName of entityNames) {
@@ -37,17 +45,29 @@ suite("Generated ModelBase classes (ESM runtime)", () => {
 			assert.equal(ModelBaseClass.prototype instanceof BaseModel, true);
 		});
 
-		test(`${className} forwards its own schema and the config to super()`, async () => {
+		test(`${className} binds its own schema and inherits the base class constructor`, async () => {
 			const mod = await import(
 				`../build/entities-model-base/${kebabName}-model-base.mjs`
 			);
 			const ModelBaseClass = mod[className];
-			const config = { table: "test-table", client: {} };
-			const instance = new ModelBaseClass(config);
+			const instance = new ModelBaseClass(client, table, salt);
 
 			assert.equal(instance instanceof BaseModel, true);
 			assert.equal(instance.schema, schema);
-			assert.equal(instance.config, config);
+			assert.equal(instance.client, client);
+			assert.equal(instance.table, table);
+			assert.equal(instance.salt, salt);
+		});
+
+		test(`${className} exposes its schema to the base class after construction`, async () => {
+			const mod = await import(
+				`../build/entities-model-base/${kebabName}-model-base.mjs`
+			);
+			const ModelBaseClass = mod[className];
+			const instance = new ModelBaseClass(client, table, salt);
+
+			assert.equal(instance.entity.schema, schema);
+			assert.equal(instance.entity.table, table);
 		});
 	}
 });
@@ -74,17 +94,19 @@ suite("Generated ModelBase classes (CJS runtime)", () => {
 			assert.equal(ModelBaseClass.prototype instanceof CjsBaseModel, true);
 		});
 
-		test(`${className} (cjs) forwards its own schema and the config to super()`, () => {
+		test(`${className} (cjs) binds its own schema and inherits the base class constructor`, () => {
 			const mod = require(
 				`../build/entities-model-base/${kebabName}-model-base.cjs`,
 			);
 			const ModelBaseClass = mod[className];
-			const config = { table: "test-table", client: {} };
-			const instance = new ModelBaseClass(config);
+			const instance = new ModelBaseClass(client, table, salt);
 
 			assert.equal(instance instanceof CjsBaseModel, true);
 			assert.equal(instance.schema, schema);
-			assert.equal(instance.config, config);
+			assert.equal(instance.client, client);
+			assert.equal(instance.table, table);
+			assert.equal(instance.salt, salt);
+			assert.equal(instance.entity.schema, schema);
 		});
 	}
 });

--- a/test/model-base.test.ts
+++ b/test/model-base.test.ts
@@ -193,3 +193,52 @@ suite("model-base kebab-case name collisions", () => {
 		assert.match(combinedOutput, /ApiKey/);
 	});
 });
+
+suite("model-base unknown options", () => {
+	test("a stale option left in a tspconfig is a compile-time error naming it, not a silent no-op", () => {
+		let combinedOutput = "";
+
+		assert.throws(
+			() =>
+				execFileSync(
+					tspBin,
+					[
+						"compile",
+						"test/main.tsp",
+						"--config",
+						"test/tspconfig.model-base-stale-option.yaml",
+					],
+					{ stdio: "pipe" },
+				),
+			(error: unknown) => {
+				assert.ok(error instanceof Error);
+				const { stdout, stderr } = error as {
+					stdout?: Buffer;
+					stderr?: Buffer;
+				};
+				combinedOutput = `${String(stdout ?? "")}${String(stderr ?? "")}`;
+				return true;
+			},
+		);
+
+		assert.match(combinedOutput, /invalid-schema/);
+		assert.match(combinedOutput, /must NOT have additional properties/);
+		// The offending option is named, so the reader knows what to remove.
+		assert.match(combinedOutput, /config-type/);
+		assert.match(combinedOutput, /model-base/);
+	});
+
+	test("no output is emitted for a config carrying a stale option", () => {
+		assert.equal(
+			existsSync(
+				fileURLToPath(
+					new URL(
+						"../build/entities-model-base-stale-option-fixture",
+						import.meta.url,
+					),
+				),
+			),
+			false,
+		);
+	});
+});

--- a/test/model-base.test.ts
+++ b/test/model-base.test.ts
@@ -77,7 +77,7 @@ suite("model-base option set", () => {
 	for (const [entityName, kebabName] of entityNames.map(
 		(name, i) => [name, kebabNames[i]] as const,
 	)) {
-		test(`${entityName}ModelBase wires the correct base class, schema and config type`, () => {
+		test(`${entityName}ModelBase binds its schema and declares no constructor`, () => {
 			const source = readFileSync(
 				modelBasePath(`${kebabName}-model-base.d.mts`),
 				"utf-8",
@@ -85,7 +85,7 @@ suite("model-base option set", () => {
 
 			assert.match(
 				source,
-				/import \{ BaseModel, type BaseModelConfig \} from "@example\/electrodb-base";/,
+				/import \{ BaseModel \} from "@example\/electrodb-base";/,
 			);
 			assert.match(
 				source,
@@ -97,7 +97,14 @@ suite("model-base option set", () => {
 					`export declare class ${entityName}ModelBase extends BaseModel<typeof ${entityName}>`,
 				),
 			);
-			assert.match(source, /constructor\(config: BaseModelConfig\);/);
+			// Annotated, not inferred: declaration emit is syntactic, so an
+			// inferred initializer would widen to `any` here.
+			assert.match(
+				source,
+				new RegExp(`protected readonly schema: typeof ${entityName};`),
+			);
+			// The base class's own constructor must come through untouched.
+			assert.doesNotMatch(source, /constructor\(/);
 		});
 
 		test(`${entityName}ModelBase file imports no other entity's schema`, () => {

--- a/test/tspconfig.model-base-collision.yaml
+++ b/test/tspconfig.model-base-collision.yaml
@@ -8,4 +8,3 @@ options:
     model-base:
       module: "@example/electrodb-base"
       class-name: "BaseModel"
-      config-type: "BaseModelConfig"

--- a/test/tspconfig.model-base-stale-option.yaml
+++ b/test/tspconfig.model-base-stale-option.yaml
@@ -1,0 +1,14 @@
+### Carries a `config-type` option that no longer exists, as a consumer
+### migrating from the constructor form of `model-base` would. Compiling with
+### this config is expected to fail.
+emit:
+  - "typespec-electrodb-emitter"
+options:
+  "typespec-electrodb-emitter":
+    package-name: "@mycorp/ddb-entities-stale-option-fixture"
+    package-version: "0.1.0"
+    emitter-output-dir: "{cwd}/build/entities-model-base-stale-option-fixture"
+    model-base:
+      module: "@example/electrodb-base"
+      class-name: "BaseModel"
+      config-type: "BaseModelConfig"

--- a/test/tspconfig.model-base.yaml
+++ b/test/tspconfig.model-base.yaml
@@ -8,4 +8,3 @@ options:
     model-base:
       module: "@example/electrodb-base"
       class-name: "BaseModel"
-      config-type: "BaseModelConfig"


### PR DESCRIPTION
`model-base` required the runtime base class to have a two-argument `(schema, config)` constructor. That is the part of a base class most likely to already be spoken for — the first adopter's base takes `(client, table, salt)` across 90 subclasses, and had to grow an adapter class whose only job was to satisfy the emission shape.

The generated class now binds the schema as a member and declares no constructor:

```ts
import { BaseModel } from "@example/electrodb-base";
import { Pet } from "./index.mjs";

export class PetModelBase extends BaseModel<typeof Pet> {
    protected readonly schema: typeof Pet = Pet;
}
```

The contract drops to a single type parameter, instantiated as `typeof Entity`. `config-type` is gone.

**What this buys:** the base class's constructor is free. Whatever it takes is what callers of the generated subclass pass.

**What it costs:** a field initializer runs after `super()` returns, so the base cannot read `this.schema` during construction. A base that built its Entity eagerly in the constructor must move to lazy access (`protected get entity() { return this.getEntity(this.schema); }`).

This replaces the constructor form outright rather than adding a `binding` option; the feature is experimental.

## Migration is checked

`model-base` now rejects options it does not recognise. A `config-type` left behind in a tspconfig fails the compile and names itself:

```
error invalid-schema: Schema violation: must NOT have additional properties (/model-base)
  additionalProperty: config-type
> 11 |       config-type: "BaseModelConfig"
     |       ^^^^^^^^^^^
```

Without this, a stale `config-type` was silently ignored: the compile succeeded and emitted the new form, so a half-finished migration was indistinguishable from a finished one — for exactly the adopters this major targets.

Closes #51
