### PR TITLE
fix: declare electrodb as a peer dependency of the emitted package

### DIFF
--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -30,6 +30,19 @@ import { type ModelBaseOptions, reportDiagnostic, StateKeys } from "./lib.js";
 import { RawCode, stringifyObject } from "./stringify.js";
 
 /**
+ * Peer dependency range declared on the emitted entities package.
+ *
+ * The floor is the version this emitter builds and type-checks its emitted
+ * output against, so it is what CI verifies — not the version where the API
+ * appeared. `CustomAttributeType`, the only electrodb value the emitted code
+ * calls, ships from 2.5.0 onward, and the emitted type surface references
+ * electrodb nowhere: the coupling is a single runtime call. The floor is
+ * therefore conservative by choice and can be widened by anyone willing to
+ * type-check the emitted output against an older electrodb.
+ */
+const ELECTRODB_PEER_RANGE = "^3.5.0";
+
+/**
  * Converts a PascalCase (or camelCase) entity name into a kebab-case base
  * name suitable for a generated file name / package export subpath, e.g.
  * "Person" -> "person", "HTTPHeader" -> "http-header", "Person2" -> "person2".
@@ -1017,6 +1030,9 @@ export async function $onEmit(context: EmitContext) {
 						},
 					},
 					...modelBaseExports,
+				},
+				peerDependencies: {
+					electrodb: ELECTRODB_PEER_RANGE,
 				},
 			},
 			null,

--- a/test/entities.test.ts
+++ b/test/entities.test.ts
@@ -643,3 +643,41 @@ suite("Enum member types (RefDataLink<Kind>)", () => {
 		);
 	});
 });
+
+suite("Emitted package manifest", () => {
+	const manifest = JSON.parse(
+		readFileSync(
+			new URL("../build/entities/package.json", import.meta.url),
+			"utf8",
+		),
+	);
+
+	test("declares electrodb as a peer dependency", () => {
+		assert.deepEqual(manifest.peerDependencies, { electrodb: "^3.5.0" });
+	});
+
+	test("does not bundle electrodb as a direct dependency", () => {
+		assert.equal(manifest.dependencies, undefined);
+	});
+
+	// The ESM and CJS entrypoints are transpiled separately, so each states the
+	// dependency in its own syntax: `from "electrodb"` and `require("electrodb")`.
+	for (const entrypoint of ["index.mjs", "index.cjs"]) {
+		test(`every bare import in ${entrypoint} is a declared peer dependency`, () => {
+			const source = readFileSync(
+				new URL(`../build/entities/${entrypoint}`, import.meta.url),
+				"utf8",
+			);
+			const specifiers = [
+				...source.matchAll(/(?:from\s*|require\(\s*)"([^"]+)"/g),
+			].map((match) => match[1]);
+			const bare = [
+				...new Set(
+					specifiers.filter((specifier) => !specifier.startsWith(".")),
+				),
+			].sort();
+
+			assert.deepEqual(bare, Object.keys(manifest.peerDependencies));
+		});
+	}
+});


### PR DESCRIPTION
## The bug

The emitted entities package has an undeclared runtime dependency on `electrodb`:

```js
// build/entities/index.mjs
import { CustomAttributeType } from "electrodb";
```

`CustomAttributeType` is called as a value at runtime, and the emitted `package.json` declared neither `dependencies` nor `peerDependencies`. The import resolves today only because every consumer of an ElectroDB entities package already installs `electrodb`, and flat `node_modules` hoisting makes someone else's copy reachable. Remove that ambient copy and the package fails to load with `Cannot find module 'electrodb'` — on plain npm, not only under pnpm or Yarn PnP.

## The fix

Declare `electrodb` as a **peer dependency** of the emitted package.

**Peer, not bundled.** Consumers pass these schema objects to their own `new Entity()`. The entities package and the consumer must share a single `electrodb` instance; a second copy would be actively wrong, so `dependencies` is not an option. `peerDependencies` states the actual contract: you bring electrodb, we don't.

## Decisions

**1. Range: `^3.5.0`.** The floor is the version the emitter builds and type-checks its emitted output against (`test:types`), so it is a statement about what CI verifies — not about where the API appeared. `CustomAttributeType` in fact ships from electrodb 2.5.0 onward (absent only in 2.0.0), and its exported signature is unchanged through 3.9.1; the emitted type surface references `electrodb` nowhere at all, so the entire coupling is one runtime call. A lower floor would very likely work, but nothing here verifies it. The floor is conservative by choice and can be widened by anyone willing to type-check the emitted output against an older electrodb — lowering it is not a breaking change.

**2. Declared unconditionally.** The `electrodb` import is emitted conditionally, only when an attribute needs `CustomAttributeType` (open records, complex unions). The peer dependency is declared unconditionally anyway:

- The package is meaningless without `electrodb` regardless of whether this particular import is present — its entire purpose is to be fed to `new Entity()`.
- A conditional declaration makes the dependency contract a function of whether some model happens to contain a union. Adding one attribute to a `.tsp` would silently change the package's manifest, breaking a strict-resolution consumer on an apparently unrelated edit.
- Deterministic output is worth more than a technically-minimal manifest.

**3. The emitter's own `devDependencies` are unchanged.** `emitter.ts` imports `electrodb` type-only, the import is erased at build, and the built `.d.ts` carries no `electrodb` references — so it never reaches the emitter's consumers. `devDependencies` is already correct.

## Not a breaking change

No existing working install breaks. npm 7+ auto-installs peer dependencies; consumers already in range see no change. A consumer pinned outside the range still installs successfully (verified against `electrodb@2.15.1`: exit 0, `ERESOLVE` warning only) and now gets a warning that reflects a real, previously silent, incompatibility.

## Tests

Four tests on the emitted manifest, alongside the existing emit tests: the peer dependency is declared, `electrodb` is not a direct dependency, and — for the ESM and CJS entrypoints separately, since each states the dependency in its own syntax (`from "electrodb"` vs `require("electrodb")`) — every bare import is covered by a declaration. The last two fail if a future change adds an undeclared import to either entrypoint. The model-base output is out of scope: its specifier is user-configured.

163 tests pass.
