### PR TITLE
feat: add prepareQuery to encode @semanticVersion attributes on read paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,29 @@ await ProductReleaseEntity.query
     .go({ order: "desc", limit: 1 });
 ```
 
+#### Reading by version
+
+ElectroDB applies attribute setters on writes only. A version handed to `get`,
+`query`, `patch`, `update`, or `delete` reaches key composition unencoded and
+addresses a row that was never written, so
+`ProductReleaseEntity.get({ productCode: "widget", version: "1.10.0" })` returns
+nothing. Encode the version before it reaches the entity.
+
+With `model-base`, the generated class does it:
+
+```typescript
+await ProductReleaseEntity.get(
+    ProductReleaseModelBase.prepareQuery({ productCode: "widget", version: "1.10.0" }),
+).go();
+```
+
+Without it, call the attribute's own setter, so the padding is never restated:
+
+```typescript
+const version = ProductRelease.attributes.version.set("1.10.0");
+await ProductReleaseEntity.get({ productCode: "widget", version }).go();
+```
+
 ## Model base classes (opt-in)
 
 Set the `model-base` option to also emit one [generation-gap](https://en.wikipedia.org/wiki/Generation_gap_(pattern))
@@ -130,6 +153,12 @@ export class PetModel extends PetModelBase {
 Your `class-name` must take one type parameter, instantiated as
 `<typeof Entity>`. Its constructor is yours: the generated class declares none,
 so it inherits whatever your base class takes.
+
+Every generated class carries a static `prepareQuery`, which encodes any
+`@semanticVersion` attributes in a set of key facets and leaves the rest alone
+(see [Reading by version](#reading-by-version)). It is present on every entity,
+decorated or not, so adding `@semanticVersion` later starts working without
+touching call sites.
 
 The schema arrives as a `protected readonly schema` member, which is set after
 `super()` returns. Your base class must therefore read it lazily rather than

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -770,6 +770,30 @@ function isModel(type: Type): asserts type is Model {
 }
 
 /**
+ * Builds the body of the model base's static `prepareQuery`.
+ *
+ * ElectroDB applies attribute setters on writes only, so a `@semanticVersion`
+ * sort key is stored zero-padded but addressed raw on every read. The encoding
+ * therefore has to happen before ElectroDB sees the facet. The padding
+ * algorithm is never restated here: each attribute's own generated `set` is
+ * the single source of the pad width.
+ */
+function buildPrepareQueryBody(
+	entityName: string,
+	semanticVersionAttributes: string[],
+): string[] {
+	return [
+		"\t\tconst prepared: Record<string, unknown> = { ...input };",
+		...semanticVersionAttributes.flatMap((attributeName) => [
+			`\t\tif (prepared.${attributeName} !== undefined) {`,
+			`\t\t\tprepared.${attributeName} = ${entityName}.attributes.${attributeName}.set(prepared.${attributeName});`,
+			"\t\t}",
+		]),
+		"\t\treturn prepared as T;",
+	];
+}
+
+/**
  * Builds the TypeScript source for a single entity's generation-gap model
  * base class. This is deliberately emitted as one standalone module per
  * entity (not a shared barrel) so a consumer that only needs a subset of
@@ -778,11 +802,19 @@ function isModel(type: Type): asserts type is Model {
  *
  * The schema is bound as a member rather than passed to a constructor, so
  * the runtime base class keeps whatever constructor it already has.
+ *
+ * `prepareQuery` is emitted for every entity, degenerating to an identity for
+ * one with no `@semanticVersion` attributes, so that adding the decorator to
+ * an existing entity does not change the package's export surface and
+ * invalidate every existing call site. It is static because it needs no
+ * instance state, and so cannot read the `schema` instance field: it
+ * references the module-scope schema import directly.
  */
 function buildModelBaseSource(
 	entityName: string,
 	options: ModelBaseOptions,
 	schemaSpecifier: string,
+	semanticVersionAttributes: string[],
 ): string {
 	const { module, "class-name": className } = options;
 
@@ -794,6 +826,10 @@ function buildModelBaseSource(
 		// Annotated explicitly: declaration emit is syntactic, so an inferred
 		// initializer would widen to `any` in the .d.mts/.d.cts output.
 		`\tprotected readonly schema: typeof ${entityName} = ${entityName};`,
+		"",
+		"\tstatic prepareQuery<T extends Record<string, unknown>>(input: T): T {",
+		...buildPrepareQueryBody(entityName, semanticVersionAttributes),
+		"\t}",
 		"}",
 		"",
 	].join("\n");
@@ -844,14 +880,31 @@ async function emitModelBaseFiles(
 			continue;
 		}
 
-		const entityName = group[0].name;
+		const model = group[0];
+		const entityName = model.name;
+		const semanticVersionState = context.program.stateSet(
+			StateKeys.semanticVersion,
+		);
+		const semanticVersionAttributes = [...model.properties.values()]
+			.filter((prop) => semanticVersionState.has(prop))
+			.map((prop) => prop.name);
 
 		// The main schema bundle has no plain "index.js" file (only
 		// index.mjs/index.cjs), so the ESM and CJS variants of this file
 		// must each import the schema from the sibling file that actually
 		// exists for their module system.
-		const esmSource = buildModelBaseSource(entityName, options, "./index.mjs");
-		const cjsSource = buildModelBaseSource(entityName, options, "./index.cjs");
+		const esmSource = buildModelBaseSource(
+			entityName,
+			options,
+			"./index.mjs",
+			semanticVersionAttributes,
+		);
+		const cjsSource = buildModelBaseSource(
+			entityName,
+			options,
+			"./index.cjs",
+			semanticVersionAttributes,
+		);
 
 		const esmDeclarations = await ts.transpileDeclaration(esmSource, {});
 		const cjsDeclarations = await ts.transpileDeclaration(cjsSource, {});

--- a/test/model-base-runtime.test.ts
+++ b/test/model-base-runtime.test.ts
@@ -59,6 +59,30 @@ suite("Generated ModelBase classes (ESM runtime)", () => {
 			assert.equal(instance.salt, salt);
 		});
 
+		// prepareQuery is emitted for every entity, decorated or not, so adding
+		// @semanticVersion to an existing entity cannot silently change the
+		// package's export surface and invalidate existing call sites.
+		test(`${className} exposes a static prepareQuery`, async () => {
+			const mod = await import(
+				`../build/entities-model-base/${kebabName}-model-base.mjs`
+			);
+			const ModelBaseClass = mod[className];
+
+			assert.equal(typeof ModelBaseClass.prepareQuery, "function");
+		});
+
+		test(`${className}.prepareQuery preserves the input's shape`, async () => {
+			const mod = await import(
+				`../build/entities-model-base/${kebabName}-model-base.mjs`
+			);
+			const ModelBaseClass = mod[className];
+			const input = { unrelatedFacet: "value" };
+			const prepared = ModelBaseClass.prepareQuery(input);
+
+			assert.deepEqual(prepared, input);
+			assert.notEqual(prepared, input);
+		});
+
 		test(`${className} exposes its schema to the base class after construction`, async () => {
 			const mod = await import(
 				`../build/entities-model-base/${kebabName}-model-base.mjs`

--- a/test/semantic-version.test.ts
+++ b/test/semantic-version.test.ts
@@ -3,6 +3,7 @@ import { execFileSync } from "node:child_process";
 import { suite, test } from "node:test";
 import { Entity } from "electrodb";
 import { ProductRelease } from "../build/entities/index.mjs";
+import { ProductReleaseModelBase } from "../build/entities-model-base/product-release-model-base.mjs";
 
 const table = "test-table";
 const tspBin = new URL("../node_modules/.bin/tsp", import.meta.url).pathname;
@@ -123,6 +124,86 @@ suite("@semanticVersion decorator", () => {
 			});
 		},
 	);
+
+	// Regression for issue #52: ElectroDB applies attribute setters on writes
+	// only, so a raw version reaches key composition unencoded on every read
+	// and addresses a row that was written padded.
+	suite("read path (issue #52)", () => {
+		const ProductReleaseEntity = new Entity(ProductRelease, { table });
+
+		const writtenSortKey = (version: string) =>
+			ProductReleaseEntity.put({ productCode: "widget", version }).params().Item
+				.sk;
+
+		test("a raw version composes a key that misses the written row", () => {
+			const raw = ProductReleaseEntity.get({
+				productCode: "widget",
+				version: "1.10.0",
+			}).params().Key.sk;
+
+			assert.notEqual(raw, writtenSortKey("1.10.0"));
+		});
+
+		test("prepareQuery composes the same key a write produced", () => {
+			const prepared = ProductReleaseEntity.get(
+				ProductReleaseModelBase.prepareQuery({
+					productCode: "widget",
+					version: "1.10.0",
+				}),
+			).params().Key.sk;
+
+			assert.equal(prepared, writtenSortKey("1.10.0"));
+		});
+
+		test("prepareQuery composes matching keys across the lexicographic trap", () => {
+			for (const version of ["1.9.0", "1.10.0", "2.0.0", "1.2.0"]) {
+				const prepared = ProductReleaseEntity.get(
+					ProductReleaseModelBase.prepareQuery({
+						productCode: "widget",
+						version,
+					}),
+				).params().Key.sk;
+
+				assert.equal(prepared, writtenSortKey(version));
+			}
+		});
+
+		test("prepareQuery composes a matching sort-key prefix for a range query", () => {
+			const { params } = ProductReleaseEntity.query
+				.releases(
+					ProductReleaseModelBase.prepareQuery({ productCode: "widget" }),
+				)
+				.gte(ProductReleaseModelBase.prepareQuery({ version: "1.9.0" }));
+
+			const { ExpressionAttributeValues } = params();
+			const lowerBound = Object.values(ExpressionAttributeValues).find(
+				(value) => typeof value === "string" && value.includes("version_"),
+			);
+
+			assert.equal(lowerBound, writtenSortKey("1.9.0"));
+		});
+
+		test("prepareQuery leaves keys without a semantic version untouched", () => {
+			assert.deepEqual(
+				ProductReleaseModelBase.prepareQuery({ productCode: "widget" }),
+				{ productCode: "widget" },
+			);
+		});
+
+		// A prepared input reaching a write path must not double-encode: the
+		// entity's own setter runs again on an already-padded value.
+		test("encoding is idempotent, so a prepared input on a write path is safe", () => {
+			const once = ProductReleaseModelBase.prepareQuery({ version: "1.10.0" });
+			const twice = ProductReleaseModelBase.prepareQuery(once);
+
+			assert.equal(once.version, "000001.000010.000000");
+			assert.equal(twice.version, once.version);
+			assert.equal(
+				ProductRelease.attributes.version.set(once.version),
+				once.version,
+			);
+		});
+	});
 });
 
 function compileFixtureExpectingFailure(fixturePath: string): string {


### PR DESCRIPTION
**Upgrading alone does not fix your get-by-version.** This ships a new API you have to call: `prepareQuery` on every read path, and `model-base` must be enabled. Without both, the bug below is unchanged. Consumers not using `model-base` encode through the schema's own setter instead — a bare `Entity.get({ version: "1.10.0" })` cannot work.

```ts
await ProductReleaseEntity.get(
    ProductReleaseModelBase.prepareQuery({ productCode: "widget", version: "1.10.0" }),
).go();
```

## The bug

`@semanticVersion` zero-pads each segment so a sort key orders by semver. ElectroDB applies attribute setters on **writes only** — `get`, `query`, `patch`, `update` and `delete` compose keys from raw input. A row written at `000001.000010.000000` is addressed at `1.10.0` and never found. The failure is silent: a missing row looks like one that was never written.

```
PUT sk: $productrelease_1#version_000001.000010.000000
GET sk: $productrelease_1#version_1.10.0
```

## Why not fix it in key composition

The issue's preferred option — make the padding a key-composition concern so reads get it too — is not available. ElectroDB's only key hook applied on both sides is `attribute.format`, built solely from the native `padding: { length, char }` option and implemented as `value.padStart(length, char)`: whole-string, not per-segment. Whole-string padding orders semver wrong (`2.9.0` sorts before `1.10.0`). The other `_makeKey` branch, `cast: "number"`, does `parseInt("1.0.0")` → `1` and loses minor/patch. With no per-segment hook, the encoding has to happen before ElectroDB sees the facet — which is why this is a call consumers must make, not something the upgrade can do for them.

## The change

Generated model base classes carry a static `prepareQuery` that encodes any `@semanticVersion` facets in a key input and leaves the rest alone. It delegates to the attribute's own generated setter, so the pad width is never restated and cannot fork. It is static because it needs no instance state, and so references the module-scope schema import rather than the `schema` instance field.

It is emitted for **every** entity, degenerating to an identity where nothing is decorated. Emitting it only on decorated entities would mean adding `@semanticVersion` to an existing entity silently changes the package's export surface, leaving every existing call site wrong and findable only by hand.

`feat:`, not `fix:` — a patch would promise that upgrading makes the bug go away, and it does not. New public API that must be adopted is a MINOR, and the changelog should surface it rather than bury it in a patch note. No breaking-change footer: a collision with a consumer's own `prepareQuery` static (TS2417) is speculative, so no major.

## Tests

`test/semantic-version.test.ts` gains a read-path suite asserting on real composed ElectroDB key params: a raw version misses the written row, a prepared one matches it, across the lexicographic trap and on a range-query bound. Encoding is idempotent, so a prepared input reaching a write path double-encodes to the same value — covered. `test/model-base-runtime.test.ts` asserts every generated class exposes `prepareQuery` and that it preserves shape without mutating the input.

5 of the new tests fail against this branch with the emitter change reverted. Suite goes 159 → 181.

Closes #52